### PR TITLE
[BE] 종일 일정 시간대 버그

### DIFF
--- a/packages/server/src/modules/schedules/schedules.service.ts
+++ b/packages/server/src/modules/schedules/schedules.service.ts
@@ -209,8 +209,12 @@ export class SchedulesService {
       createScheduleDto.categoryId ?? 7,
     )
 
+    // console.log('startDate Date() 씌우기 전 : ', createScheduleDto.startDate)
+    // console.log('endDate Date() 씌우기 전 : ', createScheduleDto.endDate)
     const startDate = new Date(createScheduleDto.startDate)
     const endDate = new Date(createScheduleDto.endDate)
+    console.log('startDate Date() 씌운 후 : ', startDate)
+    console.log('endDate Date() 씌운 후 : ', endDate)
 
     // 종료일이 시작일보다 이전인 경우 에러
     if (endDate <= startDate) {
@@ -815,23 +819,18 @@ export class SchedulesService {
   }
 
   private adjustDateForAllDay(startDate: Date, endDate: Date): [Date, Date] {
-    const adjustedStartDate = new Date(startDate)
-    const adjustedEndDate = new Date(endDate)
-
     // KST로 변환 (+9시간)
-    const kstStartDate = new Date(
-      adjustedStartDate.getTime() + 9 * 60 * 60 * 1000,
-    )
-    const kstEndDate = new Date(adjustedEndDate.getTime() + 9 * 60 * 60 * 1000)
-
+    const kstStartDate = new Date(startDate.getTime() + 9 * 60 * 60 * 1000)
+    const kstEndDate = new Date(endDate.getTime() + 9 * 60 * 60 * 1000)
+    console.log(kstStartDate, kstEndDate)
     // KST 기준으로 시간 설정
-    kstStartDate.setHours(0, 0, 0, 0)
-    kstEndDate.setHours(23, 59, 59, 999)
-
+    kstStartDate.setUTCHours(0, 0, 0, 0)
+    kstEndDate.setUTCHours(23, 59, 59, 999)
+    console.log(kstStartDate, kstEndDate)
     // UTC로 다시 변환 (-9시간)
     const utcStartDate = new Date(kstStartDate.getTime() - 9 * 60 * 60 * 1000)
     const utcEndDate = new Date(kstEndDate.getTime() - 9 * 60 * 60 * 1000)
-
+    console.log(utcStartDate, utcEndDate)
     return [utcStartDate, utcEndDate]
   }
 

--- a/packages/server/src/modules/schedules/schedules.service.ts
+++ b/packages/server/src/modules/schedules/schedules.service.ts
@@ -209,12 +209,8 @@ export class SchedulesService {
       createScheduleDto.categoryId ?? 7,
     )
 
-    // console.log('startDate Date() 씌우기 전 : ', createScheduleDto.startDate)
-    // console.log('endDate Date() 씌우기 전 : ', createScheduleDto.endDate)
     const startDate = new Date(createScheduleDto.startDate)
     const endDate = new Date(createScheduleDto.endDate)
-    console.log('startDate Date() 씌운 후 : ', startDate)
-    console.log('endDate Date() 씌운 후 : ', endDate)
 
     // 종료일이 시작일보다 이전인 경우 에러
     if (endDate <= startDate) {
@@ -819,19 +815,10 @@ export class SchedulesService {
   }
 
   private adjustDateForAllDay(startDate: Date, endDate: Date): [Date, Date] {
-    // KST로 변환 (+9시간)
-    const kstStartDate = new Date(startDate.getTime() + 9 * 60 * 60 * 1000)
-    const kstEndDate = new Date(endDate.getTime() + 9 * 60 * 60 * 1000)
-    console.log(kstStartDate, kstEndDate)
-    // KST 기준으로 시간 설정
-    kstStartDate.setUTCHours(0, 0, 0, 0)
-    kstEndDate.setUTCHours(23, 59, 59, 999)
-    console.log(kstStartDate, kstEndDate)
-    // UTC로 다시 변환 (-9시간)
-    const utcStartDate = new Date(kstStartDate.getTime() - 9 * 60 * 60 * 1000)
-    const utcEndDate = new Date(kstEndDate.getTime() - 9 * 60 * 60 * 1000)
-    console.log(utcStartDate, utcEndDate)
-    return [utcStartDate, utcEndDate]
+    return [
+      new Date(startDate.setHours(0, 0, 0, 0)),
+      new Date(endDate.setHours(23, 59, 59, 999)),
+    ]
   }
 
   private async getCategoryById(categoryId: number): Promise<Category> {


### PR DESCRIPTION
## 🔗 이슈 번호
#22 
## ✅ 작업 내용
- 종일 일정 관련 한국 시간대 적용
  - 종일 옵션이 켜질 시, (서버, 백)에서도 한국 시간대 기준 00~23:59:59로 설정
  1. UTC -> KST로 변환 (+9시간)
  2. KST 00~23:59:59로 설정 
  3. KST -> UTC로 변환 (-9시간)
## 🗣️ 공유 사항
종일 옵션이 켜진 상태에서 반환되는 시간은 Z시 입니다. (UTC)
반환되는 시간에서 +9시간을 했을 때, 
startDate가 00:00:00이 되고 endDate가 23:59:59인지 확인해주세요.