### PR TITLE
[FE/BE] husky, lint-staged 설정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,10 @@
+echo "🔎 eslint 적용 중"
+
+if yarn lint-staged; then
+  echo "⭕️ eslint 규칙 적용 성공"
+  exit 0
+else
+  echo "❌ eslint 규칙 적용 실패"
+  exit 1
+fi
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "check-format": "prettier --check .",
     "lint:all": "yarn eslint --fix",
     "lint:client": "yarn workspace client lint --fix",
-    "lint:server": "yarn workspace server lint --fix"
+    "lint:server": "yarn workspace server lint --fix",
+    "prepare": "husky"
   },
   "dependencies": {
     "axios": "^1.7.7"
@@ -30,9 +31,17 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.16.0"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   },
   "packageManager": "yarn@1.22.21"
 }

--- a/packages/client/.husky/pre-commit
+++ b/packages/client/.husky/pre-commit
@@ -1,1 +1,0 @@
-yarn lint-staged

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,7 +8,6 @@
     "build": "tsc -b && vite build",
     "lint": "eslint src",
     "preview": "vite preview",
-    "prepare": "husky",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.tsx\" \"test/**/*.ts\" \"test/**/*.tsx\""
   },
   "dependencies": {
@@ -35,8 +34,6 @@
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
     "clsx": "^2.1.1",
-    "husky": "^9.1.6",
-    "lint-staged": "^15.2.10",
     "postcss": "^8.4.47",
     "prettier-plugin-tailwindcss": "^0.6.6",
     "tailwind-merge": "^2.5.2",
@@ -44,11 +41,5 @@
     "vite": "^5.4.1",
     "vite-plugin-pwa": "^0.20.5",
     "vite-tsconfig-paths": "^5.0.1"
-  },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,10 +5183,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^9.1.6:
-  version "9.1.6"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
-  integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -6164,10 +6164,15 @@ lilconfig@^2.1.0:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
   integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
 
-lilconfig@^3.0.0, lilconfig@~3.1.2:
+lilconfig@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.2.tgz#e4a7c3cb549e3a606c8dcc32e5ae1005e62c05cb"
   integrity sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==
+
+lilconfig@~3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"


### PR DESCRIPTION
## 🔗 이슈 번호
#25 

## ✅ 작업 내용
<img width="458" alt="스크린샷 2024-12-04 오후 4 20 40" src="https://github.com/user-attachments/assets/94b2e649-4ad8-44e9-8a3e-a0130dea0cc7">

루트에 husky, lint-staged를 적용했습니다.

## 🗣️ 공유 사항
`pre-commit` git hook을 설정했습니다.
스테이징된 변경사항을 커밋하면 js, ts, jsx, tsx 확장자 파일들에 eslint, prettier 규칙이 적용됩니다.