### PR TITLE
hotfix: 파일명에 앞에 붙는 맥 운영체제의 특수문자제거

### DIFF
--- a/packages/client/src/test/sum.test.ts
+++ b/packages/client/src/test/sum.test.ts
@@ -1,0 +1,7 @@
+// sum.test.ts
+import { expect, test } from 'vitest';
+import { sum } from './sum';
+
+test('덧셈 테스트 1 + 2 = 3', () => {
+  expect(sum(1, 2)).toBe(3);
+});


### PR DESCRIPTION
## 🔗 이슈 번호
#38 
## ✅ 작업 내용
맥 운영체제만의 파일 명 앞에 붙어 있는 의도치 않은 특수문자 제거함.

## 🗣️ 공유 사항
파일명에 의도치 않은 문자가 들어가는 것을 유의하면 좋을 거 같습니다.