### PR TITLE
[BE] 엔티티 fk 일관성 설정

### DIFF
--- a/packages/server/src/entities/manager-invitation.entity.ts
+++ b/packages/server/src/entities/manager-invitation.entity.ts
@@ -4,7 +4,10 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm'
+import { User } from './user.entity'
 
 export enum InvitationStatus {
   PENDING = 'PENDING', // 초대가 발송되었지만, 아직 응답하지 않은 상태
@@ -40,4 +43,12 @@ export class ManagerInvitation {
 
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date
+
+  @ManyToOne(() => User, (user) => user.sentManagerInvitations)
+  @JoinColumn({ name: 'manager_uuid', referencedColumnName: 'userUuid' })
+  manager: User
+
+  @ManyToOne(() => User, (user) => user.receivedManagerInvitations)
+  @JoinColumn({ name: 'subordinate_uuid', referencedColumnName: 'userUuid' })
+  subordinate: User
 }

--- a/packages/server/src/entities/manager-subordinate.entity.ts
+++ b/packages/server/src/entities/manager-subordinate.entity.ts
@@ -3,7 +3,10 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  JoinColumn,
+  ManyToOne,
 } from 'typeorm'
+import { User } from './user.entity'
 
 @Entity('manager_subordinate')
 export class ManagerSubordinate {
@@ -18,4 +21,12 @@ export class ManagerSubordinate {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date
+
+  @ManyToOne(() => User, (user) => user.managers)
+  @JoinColumn({ name: 'manager_uuid', referencedColumnName: 'userUuid' })
+  manager: User
+
+  @ManyToOne(() => User, (user) => user.subordinates)
+  @JoinColumn({ name: 'subordinate_uuid', referencedColumnName: 'userUuid' })
+  subordinate: User
 }

--- a/packages/server/src/entities/user.entity.ts
+++ b/packages/server/src/entities/user.entity.ts
@@ -15,6 +15,7 @@ import { UserRoutine } from './user-routine.entity'
 import { GroupInvitation } from './group-invitation.entity'
 import { GroupSchedule } from './group-schedule.entity'
 import { UserGroup } from './user-group.entity'
+import { ManagerSubordinate } from './manager-subordinate.entity'
 
 @Entity('user')
 export class User {
@@ -81,4 +82,16 @@ export class User {
 
   @OneToMany(() => UserGroup, (userGroup) => userGroup.user)
   groupMembers?: UserGroup[]
+
+  @OneToMany(
+    () => ManagerSubordinate,
+    (managerSubordinate) => managerSubordinate.manager,
+  )
+  managers?: ManagerSubordinate[]
+
+  @OneToMany(
+    () => ManagerSubordinate,
+    (managerSubordinate) => managerSubordinate.subordinate,
+  )
+  subordinates?: ManagerSubordinate[]
 }

--- a/packages/server/src/entities/user.entity.ts
+++ b/packages/server/src/entities/user.entity.ts
@@ -16,6 +16,7 @@ import { GroupInvitation } from './group-invitation.entity'
 import { GroupSchedule } from './group-schedule.entity'
 import { UserGroup } from './user-group.entity'
 import { ManagerSubordinate } from './manager-subordinate.entity'
+import { ManagerInvitation } from './manager-invitation.entity'
 
 @Entity('user')
 export class User {
@@ -94,4 +95,10 @@ export class User {
     (managerSubordinate) => managerSubordinate.subordinate,
   )
   subordinates?: ManagerSubordinate[]
+
+  @OneToMany(() => ManagerInvitation, (invitation) => invitation.manager)
+  sentManagerInvitations?: ManagerInvitation[]
+
+  @OneToMany(() => ManagerInvitation, (invitation) => invitation.subordinate)
+  receivedManagerInvitations?: ManagerInvitation[]
 }

--- a/packages/server/src/modules/manager/manager.service.ts
+++ b/packages/server/src/modules/manager/manager.service.ts
@@ -221,7 +221,7 @@ export class ManagerService {
   }
 
   private async createManagerSubordinate(
-    invitation: ManagerInvitation,
+    invitation: CreateInvitationDto,
   ): Promise<void> {
     try {
       const managerSubordinate = this.managerSubordinateRepository.create({


### PR DESCRIPTION
## 🔗 이슈 번호
#44 
## ✅ 작업 내용
manager-invitation 엔티티에서 userUuid를 참조 설정

manager-subordinate 엔티티에서 userUuid를 참조 설정

user-group 엔티티에서 userUuid를 참조 설정