### PR TITLE
[BE] AI 및 GPT 처리 로직 서비스 분리

### DIFF
--- a/packages/server/src/modules/schedules/OCR-transcription.service.ts
+++ b/packages/server/src/modules/schedules/OCR-transcription.service.ts
@@ -8,7 +8,7 @@ import { SchedulesService } from './schedules.service'
 import { CreateScheduleDto } from './dto/create-schedule.dto'
 import { UsersRoutineService } from '../users/users-routine.service'
 import { UserRoutineResponseDto } from '../users/dto/response-user-routine.dto'
-import { Multer } from 'multer'
+import { AiService } from './ai.service'
 
 @Injectable()
 export class OCRTranscriptionService {
@@ -20,6 +20,8 @@ export class OCRTranscriptionService {
     @Inject(forwardRef(() => SchedulesService))
     private scheduleService: SchedulesService,
     private usersRoutineService: UsersRoutineService,
+    @Inject(forwardRef(() => AiService))
+    private aiService: AiService,
   ) {
     this.client = new ImageAnnotatorClient(this.getCredentials())
   }
@@ -133,8 +135,8 @@ export class OCRTranscriptionService {
     })
 
     const gptResponseContent = gptResponse.choices[0].message.content
-    console.log(this.scheduleService.parseGptResponse(gptResponseContent))
-    return this.scheduleService.parseGptResponse(gptResponseContent)
+    console.log(this.aiService.parseGptResponse(gptResponseContent))
+    return this.aiService.parseGptResponse(gptResponseContent)
   }
 
   private async extractMedicationInfo(

--- a/packages/server/src/modules/schedules/ai.service.ts
+++ b/packages/server/src/modules/schedules/ai.service.ts
@@ -1,0 +1,170 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import OpenAI from 'openai'
+import { Repository } from 'typeorm'
+import { UsersService } from '../users/users.service'
+import { VoiceTranscriptionService } from './voice-transcription.service'
+import { CreateScheduleDto } from './dto/create-schedule.dto'
+import { Category } from '@/entities/category.entity'
+import { InjectRepository } from '@nestjs/typeorm'
+
+@Injectable()
+export class AiService {
+  private readonly openai: OpenAI
+
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+    private readonly voiceTranscriptionService: VoiceTranscriptionService,
+    private readonly usersService: UsersService,
+  ) {
+    const openaiApiKey = this.configService.get<string>('OPENAI_API_KEY')
+    this.openai = new OpenAI({ apiKey: openaiApiKey })
+  }
+
+  /**
+   * 날짜를 YYYY-MM-DD HH:mm:ss 형식으로 변환합니다.
+   */
+  private async formatDateToYYYYMMDDHHMMSS(date: Date): Promise<string> {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    const hours = String(date.getHours()).padStart(2, '0')
+    const minutes = String(date.getMinutes()).padStart(2, '0')
+    const seconds = String(date.getSeconds()).padStart(2, '0')
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+  }
+
+  /**
+   * GPT 응답을 파싱합니다.
+   */
+  parseGptResponse(response: string): any[] {
+    try {
+      return JSON.parse(response)
+    } catch (error) {
+      console.error('Error parsing GPT response:', error)
+      throw new Error('Failed to parse GPT response')
+    }
+  }
+
+  /**
+   * 전사 데이터를 OpenAI GPT 모델에 넘겨서 처리합니다.
+   */
+  private async processWithGpt(
+    transcriptionResult: any,
+    currentDateTime: string,
+  ): Promise<CreateScheduleDto[]> {
+    const formattedDate = await this.formatDateToYYYYMMDDHHMMSS(
+      new Date(currentDateTime),
+    )
+
+    const gptResponse = await this.openai.chat.completions.create({
+      model: this.configService.get<string>('OPENAI_FINETUNING_MODEL'),
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are an AI assistant that extracts startDate, endDate, title, place, isAllDay, and category information from conversations. 카테고리[병원, 복약, 가족, 종교, 운동, 경조사, 기타]',
+        },
+        {
+          role: 'user',
+          content: `{Today : ${formattedDate}, conversations : ${transcriptionResult}}`,
+        },
+      ],
+    })
+    const gptResponseContent = gptResponse.choices[0].message.content
+    console.log(gptResponseContent)
+
+    const parsedResponse = this.parseGptResponse(gptResponseContent)
+    return this.convertGptResponseToCreateScheduleDto(parsedResponse)
+  }
+
+  /**
+   * OCR 결과를 OpenAI GPT 모델에 넘겨서 처리합니다.
+   */
+  async processWithGptOCR(OCRResult: string): Promise<any> {
+    const gptResponse = await this.openai.chat.completions.create({
+      model: this.configService.get<string>('OPENAI_FINETUNING_MODEL_OCR'),
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are an AI assistant that extracts startDate, endDate, category, intent, isAllDay and place information from conversations. 카테고리[병원, 복약, 가족, 종교, 운동, 경조사, 기타]',
+        },
+        {
+          role: 'user',
+          content: `${OCRResult}`,
+        },
+      ],
+      max_tokens: 1000,
+      temperature: 0,
+    })
+
+    const gptResponseContent = gptResponse.choices[0].message.content
+    return this.parseGptResponse(gptResponseContent)
+  }
+
+  private async convertGptResponseToCreateScheduleDto(
+    gptEvents: any,
+  ): Promise<CreateScheduleDto[]> {
+    const allCategories = await this.categoryRepository.find()
+    const categoryMap = allCategories.reduce((acc, category) => {
+      acc[category.categoryName] = category.categoryId
+      return acc
+    }, {})
+
+    // 추가
+    const eventsArray = Array.isArray(gptEvents) ? gptEvents : [gptEvents]
+
+    console.log('gptEvents:', eventsArray)
+
+    return eventsArray.map((event) => {
+      const dto = new CreateScheduleDto()
+      dto.startDate = new Date(event.startDate)
+      dto.endDate = new Date(event.endDate)
+      dto.title = event.intent || event.title || '새로운 일정'
+      dto.place = event.place || ''
+      dto.isAllDay = event.isAllDay || false
+      dto.categoryId = categoryMap[event.category] || 7 // 기본값
+      return dto
+    })
+  }
+
+  private async validateUser(userUuid: string) {
+    const userExists = await this.usersService.checkUserExists(userUuid)
+    if (!userExists) {
+      throw new NotFoundException(
+        `해당 UUID : ${userUuid} 를 가진 사용자는 없습니다.`,
+      )
+    }
+  }
+
+  /**
+   * RTZR을 사용하여 음성을 전사하고 GPT로 처리합니다.
+   */
+  async transcribeRTZRAndFetchResultWithGpt(
+    file: Express.Multer.File,
+    currentDateTime: string,
+    userUuid: string,
+  ) {
+    await this.validateUser(userUuid)
+    const transcribe =
+      await this.voiceTranscriptionService.RTZRTranscribeResult(file)
+    return this.processWithGpt(transcribe, currentDateTime)
+  }
+
+  /**
+   * Whisper를 사용하여 음성을 전사하고 GPT로 처리합니다.
+   */
+  async transcribeWhisperAndFetchResultWithGpt(
+    file: Express.Multer.File,
+    currentDateTime: string,
+    userUuid: string,
+  ) {
+    await this.validateUser(userUuid)
+    const transcribe =
+      await this.voiceTranscriptionService.whisperTranscribeResult(file)
+    return this.processWithGpt(transcribe, currentDateTime)
+  }
+}

--- a/packages/server/src/modules/schedules/schedules.controller.ts
+++ b/packages/server/src/modules/schedules/schedules.controller.ts
@@ -32,8 +32,8 @@ import { OCRTranscriptionService } from './OCR-transcription.service'
 import { AuthGuard } from '@nestjs/passport'
 import { UpdateScheduleDto } from './dto/update-schedule.dto'
 import { ManagerService } from '../manager/manager.service'
-import { Multer } from 'multer'
 import { GetUserUuid } from '@/common/decorators/get-user-uuid.decorator'
+import { AiService } from './ai.service'
 
 @ApiTags('Schedules')
 @UseGuards(AuthGuard('jwt'))
@@ -44,6 +44,7 @@ export class SchedulesController {
     private readonly schedulesService: SchedulesService,
     private readonly ocrTranscriptionService: OCRTranscriptionService,
     private readonly managerService: ManagerService,
+    private readonly aiService: AiService,
   ) {}
 
   @Get('day')
@@ -521,7 +522,7 @@ export class SchedulesController {
     @UploadedFile() file: Express.Multer.File,
     @Body('currentDateTime') currentDateTime: string,
   ): Promise<CreateScheduleDto[]> {
-    return await this.schedulesService.transcribeRTZRAndFetchResultWithGpt(
+    return await this.aiService.transcribeRTZRAndFetchResultWithGpt(
       file,
       currentDateTime,
       userUuid,
@@ -542,7 +543,7 @@ export class SchedulesController {
     @UploadedFile() file: Express.Multer.File,
     @Body('currentDateTime') currentDateTime: string,
   ): Promise<CreateScheduleDto[]> {
-    return await this.schedulesService.transcribeWhisperAndFetchResultWithGpt(
+    return await this.aiService.transcribeWhisperAndFetchResultWithGpt(
       file,
       currentDateTime,
       userUuid,

--- a/packages/server/src/modules/schedules/schedules.module.ts
+++ b/packages/server/src/modules/schedules/schedules.module.ts
@@ -15,8 +15,8 @@ import { UsersModule } from '../users/users.module'
 import { ManagerModule } from '../manager/manager.module'
 import { GroupModule } from '../group/group.module'
 import { GroupSchedule } from '@/entities/group-schedule.entity'
-import { Multer } from 'multer'
 import { ScheduleRecurring } from '@/entities/recurring-schedule.entity'
+import { AiService } from './ai.service'
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -39,6 +39,7 @@ import { ScheduleRecurring } from '@/entities/recurring-schedule.entity'
     VoiceTranscriptionService,
     OCRTranscriptionService,
     UsersService,
+    AiService,
   ],
 })
 export class SchedulesModule {}

--- a/packages/server/src/modules/schedules/schedules.service.ts
+++ b/packages/server/src/modules/schedules/schedules.service.ts
@@ -44,8 +44,6 @@ export class SchedulesService {
     @InjectRepository(GroupSchedule)
     private groupScheduleRepository: Repository<GroupSchedule>,
     private groupService: GroupService,
-    @InjectDataSource()
-    private dataSource: DataSource,
   ) {
     const openaiApiKey = this.configService.get<string>('OPENAI_API_KEY')
     this.openai = new OpenAI({ apiKey: openaiApiKey })
@@ -1007,134 +1005,134 @@ export class SchedulesService {
 
   // GPT 관련 메서드
 
-  /**
-   * GPT 응답을 파싱합니다.
-   */
-  parseGptResponse(response: string): any[] {
-    try {
-      return JSON.parse(response)
-    } catch (error) {
-      console.error('Error parsing GPT response:', error)
-      throw new Error('Failed to parse GPT response')
-    }
-  }
+  // /**
+  //  * GPT 응답을 파싱합니다.
+  //  */
+  // parseGptResponse(response: string): any[] {
+  //   try {
+  //     return JSON.parse(response)
+  //   } catch (error) {
+  //     console.error('Error parsing GPT response:', error)
+  //     throw new Error('Failed to parse GPT response')
+  //   }
+  // }
 
-  /**
-   * 전사 데이터를 OpenAI GPT 모델에 넘겨서 처리합니다.
-   */
-  private async processWithGpt(
-    transcriptionResult: any,
-    currentDateTime: string,
-  ): Promise<CreateScheduleDto[]> {
-    const formattedDate = await this.formatDateToYYYYMMDDHHMMSS(
-      new Date(currentDateTime),
-    )
+  // /**
+  //  * 전사 데이터를 OpenAI GPT 모델에 넘겨서 처리합니다.
+  //  */
+  // private async processWithGpt(
+  //   transcriptionResult: any,
+  //   currentDateTime: string,
+  // ): Promise<CreateScheduleDto[]> {
+  //   const formattedDate = await this.formatDateToYYYYMMDDHHMMSS(
+  //     new Date(currentDateTime),
+  //   )
 
-    const gptResponse = await this.openai.chat.completions.create({
-      model: this.configService.get<string>('OPENAI_FINETUNING_MODEL'),
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are an AI assistant that extracts startDate, endDate, title, place, isAllDay, and category information from conversations. 카테고리[병원, 복약, 가족, 종교, 운동, 경조사, 기타]',
-        },
-        {
-          role: 'user',
-          content: `{Today : ${formattedDate}, conversations : ${transcriptionResult}}`,
-        },
-      ],
-    })
-    const gptResponseContent = gptResponse.choices[0].message.content
-    console.log(gptResponseContent)
+  //   const gptResponse = await this.openai.chat.completions.create({
+  //     model: this.configService.get<string>('OPENAI_FINETUNING_MODEL'),
+  //     messages: [
+  //       {
+  //         role: 'system',
+  //         content:
+  //           'You are an AI assistant that extracts startDate, endDate, title, place, isAllDay, and category information from conversations. 카테고리[병원, 복약, 가족, 종교, 운동, 경조사, 기타]',
+  //       },
+  //       {
+  //         role: 'user',
+  //         content: `{Today : ${formattedDate}, conversations : ${transcriptionResult}}`,
+  //       },
+  //     ],
+  //   })
+  //   const gptResponseContent = gptResponse.choices[0].message.content
+  //   console.log(gptResponseContent)
 
-    const parsedResponse = this.parseGptResponse(gptResponseContent)
-    return this.convertGptResponseToCreateScheduleDto(parsedResponse)
-  }
+  //   const parsedResponse = this.parseGptResponse(gptResponseContent)
+  //   return this.convertGptResponseToCreateScheduleDto(parsedResponse)
+  // }
 
-  /**
-   * OCR 결과를 OpenAI GPT 모델에 넘겨서 처리합니다.
-   */
-  async processWithGptOCR(OCRResult: string): Promise<any> {
-    const gptResponse = await this.openai.chat.completions.create({
-      model: this.configService.get<string>('OPENAI_FINETUNING_MODEL_OCR'),
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are an AI assistant that extracts startDate, endDate, category, intent, isAllDay and place information from conversations. 카테고리[병원, 복약, 가족, 종교, 운동, 경조사, 기타]',
-        },
-        {
-          role: 'user',
-          content: `${OCRResult}`,
-        },
-      ],
-      max_tokens: 1000,
-      temperature: 0,
-    })
+  // /**
+  //  * OCR 결과를 OpenAI GPT 모델에 넘겨서 처리합니다.
+  //  */
+  // async processWithGptOCR(OCRResult: string): Promise<any> {
+  //   const gptResponse = await this.openai.chat.completions.create({
+  //     model: this.configService.get<string>('OPENAI_FINETUNING_MODEL_OCR'),
+  //     messages: [
+  //       {
+  //         role: 'system',
+  //         content:
+  //           'You are an AI assistant that extracts startDate, endDate, category, intent, isAllDay and place information from conversations. 카테고리[병원, 복약, 가족, 종교, 운동, 경조사, 기타]',
+  //       },
+  //       {
+  //         role: 'user',
+  //         content: `${OCRResult}`,
+  //       },
+  //     ],
+  //     max_tokens: 1000,
+  //     temperature: 0,
+  //   })
 
-    const gptResponseContent = gptResponse.choices[0].message.content
-    return this.parseGptResponse(gptResponseContent)
-  }
+  //   const gptResponseContent = gptResponse.choices[0].message.content
+  //   return this.parseGptResponse(gptResponseContent)
+  // }
 
-  /**
-   * 날짜를 YYYY-MM-DD HH:mm:ss 형식으로 변환합니다.
-   */
-  private async formatDateToYYYYMMDDHHMMSS(date: Date): Promise<string> {
-    const year = date.getFullYear()
-    const month = String(date.getMonth() + 1).padStart(2, '0')
-    const day = String(date.getDate()).padStart(2, '0')
-    const hours = String(date.getHours()).padStart(2, '0')
-    const minutes = String(date.getMinutes()).padStart(2, '0')
-    const seconds = String(date.getSeconds()).padStart(2, '0')
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
-  }
+  // /**
+  //  * 날짜를 YYYY-MM-DD HH:mm:ss 형식으로 변환합니다.
+  //  */
+  // private async formatDateToYYYYMMDDHHMMSS(date: Date): Promise<string> {
+  //   const year = date.getFullYear()
+  //   const month = String(date.getMonth() + 1).padStart(2, '0')
+  //   const day = String(date.getDate()).padStart(2, '0')
+  //   const hours = String(date.getHours()).padStart(2, '0')
+  //   const minutes = String(date.getMinutes()).padStart(2, '0')
+  //   const seconds = String(date.getSeconds()).padStart(2, '0')
+  //   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+  // }
 
-  private async convertGptResponseToCreateScheduleDto(
-    gptEvents: any[],
-  ): Promise<CreateScheduleDto[]> {
-    const allCategories = await this.categoryRepository.find()
-    const categoryMap = allCategories.reduce((acc, category) => {
-      acc[category.categoryName] = category.categoryId
-      return acc
-    }, {})
-    console.log(gptEvents)
-    return gptEvents.map((event) => {
-      const dto = new CreateScheduleDto()
-      dto.startDate = new Date(event.startDate)
-      dto.endDate = new Date(event.endDate)
-      dto.title = event.intent || event.title || '새로운 일정'
-      dto.place = event.place || ''
-      dto.isAllDay = event.isAllDay || false
-      dto.categoryId = categoryMap[event.category] || 7 // 7은 '기타' 카테고리의 ID로 가정
-      return dto
-    })
-  }
+  // private async convertGptResponseToCreateScheduleDto(
+  //   gptEvents: any[],
+  // ): Promise<CreateScheduleDto[]> {
+  //   const allCategories = await this.categoryRepository.find()
+  //   const categoryMap = allCategories.reduce((acc, category) => {
+  //     acc[category.categoryName] = category.categoryId
+  //     return acc
+  //   }, {})
+  //   console.log(gptEvents)
+  //   return gptEvents.map((event) => {
+  //     const dto = new CreateScheduleDto()
+  //     dto.startDate = new Date(event.startDate)
+  //     dto.endDate = new Date(event.endDate)
+  //     dto.title = event.intent || event.title || '새로운 일정'
+  //     dto.place = event.place || ''
+  //     dto.isAllDay = event.isAllDay || false
+  //     dto.categoryId = categoryMap[event.category] || 7 // 7은 '기타' 카테고리의 ID로 가정
+  //     return dto
+  //   })
+  // }
 
-  /**
-   * RTZR을 사용하여 음성을 전사하고 GPT로 처리합니다.
-   */
-  async transcribeRTZRAndFetchResultWithGpt(
-    file: Express.Multer.File,
-    currentDateTime: string,
-    userUuid: string,
-  ) {
-    await this.validateUser(userUuid)
-    const transcribe =
-      await this.voiceTranscriptionService.RTZRTranscribeResult(file)
-    return this.processWithGpt(transcribe, currentDateTime)
-  }
+  // /**
+  //  * RTZR을 사용하여 음성을 전사하고 GPT로 처리합니다.
+  //  */
+  // async transcribeRTZRAndFetchResultWithGpt(
+  //   file: Express.Multer.File,
+  //   currentDateTime: string,
+  //   userUuid: string,
+  // ) {
+  //   await this.validateUser(userUuid)
+  //   const transcribe =
+  //     await this.voiceTranscriptionService.RTZRTranscribeResult(file)
+  //   return this.processWithGpt(transcribe, currentDateTime)
+  // }
 
-  /**
-   * Whisper를 사용하여 음성을 전사하고 GPT로 처리합니다.
-   */
-  async transcribeWhisperAndFetchResultWithGpt(
-    file: Express.Multer.File,
-    currentDateTime: string,
-    userUuid: string,
-  ) {
-    await this.validateUser(userUuid)
-    const transcribe =
-      await this.voiceTranscriptionService.whisperTranscribeResult(file)
-    return this.processWithGpt(transcribe, currentDateTime)
-  }
+  // /**
+  //  * Whisper를 사용하여 음성을 전사하고 GPT로 처리합니다.
+  //  */
+  // async transcribeWhisperAndFetchResultWithGpt(
+  //   file: Express.Multer.File,
+  //   currentDateTime: string,
+  //   userUuid: string,
+  // ) {
+  //   await this.validateUser(userUuid)
+  //   const transcribe =
+  //     await this.voiceTranscriptionService.whisperTranscribeResult(file)
+  //   return this.processWithGpt(transcribe, currentDateTime)
+  // }
 }


### PR DESCRIPTION
## 🔗 이슈 번호
#49 
## ✅ 작업 내용
- 기존 `SchedulesService` 내에 포함되어 있던 GPT 관련 로직을 `AiService`로 분리
  - `processWithGpt`와 `processWithGptOCR` 메서드를 `AiService`로 이동하여 AI 관련 기능을 전담하도록 구현
  - `convertGptResponseToCreateScheduleDto` 메서드도 `AiService`에서 관리하며, 단일 객체와 배열을 모두 처리할 수 있도록 수정
- `OCRTranscriptionService` 및 `SchedulesService`에서 `AiService`를 의존성 주입하여 GPT 처리 로직 호출
- `convertGptResponseToCreateScheduleDto`에서 `gptEvents`가 배열이 아닐 경우 배열로 변환하여 처리
## 🗣️ 공유 사항
