### PR TITLE
[FE] 일정폼 반복 기능 추가

### DIFF
--- a/packages/client/src/components/common/schedule-form/ScheduleForm.tsx
+++ b/packages/client/src/components/common/schedule-form/ScheduleForm.tsx
@@ -6,12 +6,11 @@ import CategoryField from './field-components/CategoryField'
 import DateTimeField from './field-components/DateTimeField'
 import TextAreaField from './field-components/TextAreaField'
 import TextInputField from './field-components/TextInputField'
-// import GroupField from './field-components/GroupField'
-// import RepetitionField from './field-components/RepetitionField'
 import { addDays, setHours, setMilliseconds, setMinutes, setSeconds, startOfToday } from 'date-fns'
 import ToggleField from './field-components/ToggleField'
 import BaseSection from './field-components/BaseSection'
 import GroupField from './field-components/GroupField'
+import RepetitionField from './field-components/RepetitionField'
 
 type Props = {
   defaultValue?: Partial<ISchedule>
@@ -19,12 +18,14 @@ type Props = {
   onSubmit: (data: IPartialScheduleForm) => void
   /** 하단 등록하기 버튼 메세지 */
   buttonMessage?: string
+  isUpdateForm?: boolean
 }
 
 const ScheduleForm = ({
   defaultValue,
   onSubmit,
   buttonMessage = '등록하기',
+  isUpdateForm
 }: Props) => {
   const [isDetailOpen, setIsDetailOpen] = useState<boolean>(false)
 
@@ -230,7 +231,9 @@ const ScheduleForm = ({
                 )}
               />
 
-              {/* <RepetitionField /> */}
+              <RepetitionField 
+                isUpdateForm={isUpdateForm}
+              />
 
               <Controller
                 control={formScheduleCreate.control}

--- a/packages/client/src/components/common/schedule-form/ScheduleForm.tsx
+++ b/packages/client/src/components/common/schedule-form/ScheduleForm.tsx
@@ -71,20 +71,45 @@ const ScheduleForm = ({
   /** defaultValue가 프로퍼티로 넘어온 경우, 폼을 defaultValue로 초기화 */
   useEffect(() => {
     if (defaultValue) {
-      formScheduleCreate.reset({
-        title: defaultValue.title,
-        categoryId: defaultValue.category?.categoryId,
-        isAllDay: defaultValue.isAllDay,
-        startDate: new Date(defaultValue.startDate!),
-        endDate: new Date(defaultValue.endDate!),
-        place: defaultValue.place,
-        memo: defaultValue.memo,
-        isRecurring: defaultValue.isRecurring,
-        groupInfo: defaultValue?.groupInfo?.map((group) => ({
-          groupId: group.groupId,
-          userUuids: group.users.map(user => user.userUuid)
-        })) ?? []
-      })
+      if (!defaultValue?.recurringInfo) {
+        formScheduleCreate.reset({
+          title: defaultValue.title,
+          categoryId: defaultValue.category?.categoryId,
+          isAllDay: defaultValue.isAllDay,
+          startDate: new Date(defaultValue.startDate!),
+          endDate: new Date(defaultValue.endDate!),
+          place: defaultValue.place,
+          memo: defaultValue.memo,
+          isRecurring: defaultValue.isRecurring,
+          groupInfo: defaultValue?.groupInfo?.map((group) => ({
+            groupId: group.groupId,
+            userUuids: group.users.map(user => user.userUuid)
+          })) ?? []
+        })
+      } else {
+        formScheduleCreate.reset({
+          title: defaultValue.title,
+          categoryId: defaultValue.category?.categoryId,
+          isAllDay: defaultValue.isAllDay,
+          startDate: new Date(defaultValue.startDate!),
+          endDate: new Date(defaultValue.endDate!),
+          place: defaultValue.place,
+          memo: defaultValue.memo,
+          isRecurring: true,
+          groupInfo: defaultValue?.groupInfo?.map((group) => ({
+            groupId: group.groupId,
+            userUuids: group.users.map(user => user.userUuid)
+          })) ?? [],
+          recurringOptions: {
+            repeatEndDate: defaultValue?.recurringInfo?.repeatEndDate,
+            recurringInterval: defaultValue?.recurringInfo?.interval,
+            repeatType: defaultValue?.recurringInfo?.repeatType,
+            ...(defaultValue?.recurringInfo?.daysOfWeek && { recurringDaysOfWeek: defaultValue?.recurringInfo?.daysOfWeek }),
+            ...(defaultValue?.recurringInfo?.dayOfMonth && { recurringDayOfMonth: defaultValue?.recurringInfo?.dayOfMonth }),
+            ...(defaultValue?.recurringInfo?.monthOfYear && { recurringMonthOfYear: defaultValue?.recurringInfo?.monthOfYear })
+          }
+        })
+      }
     }
   }, [defaultValue, formScheduleCreate])
 

--- a/packages/client/src/components/common/schedule-form/field-components/RepetitionField.tsx
+++ b/packages/client/src/components/common/schedule-form/field-components/RepetitionField.tsx
@@ -1,158 +1,182 @@
-// import Select, { components } from 'react-select'
-// import BaseSection from './BaseSection'
-// import { useState } from 'react'
-// import { useModal } from '@/hooks/use-modal'
+import Select, { components } from 'react-select'
+import BaseSection from './BaseSection'
+import { useEffect, useState } from 'react'
+import { useModal } from '@/hooks/use-modal'
 import { useFormContext } from 'react-hook-form'
-// import RepititionSetModal from './RepititionSetModal'
-// import { RecurringOptionValue } from '@/types/schedules'
+import RepititionSetModal from './RepititionSetModal'
+import { RecurringOptionValue } from '@/types/schedules'
+import { addDays } from 'date-fns'
 
-// type RecurringOption = {
-//   value: RecurringOptionValue
-//   label: string
-// }
+type RecurringOption = {
+  value: RecurringOptionValue
+  label: string
+}
 
-// const options: RecurringOption[] = [
-//   {
-//     value: 'none',
-//     label: '없음',
-//   },
-//   {
-//     value: 'daily',
-//     label: '일간 반복',
-//   },
-//   {
-//     value: 'weekly',
-//     label: '주간 반복',
-//   },
-//   {
-//     value: 'monthly',
-//     label: '월간 반복',
-//   },
-//   {
-//     value: 'yearly',
-//     label: '연간 반복',
-//   },
-// ]
+const options: RecurringOption[] = [
+  {
+    value: 'none',
+    label: '설정 취소',
+  },
+  {
+    value: 'daily',
+    label: '일간 반복',
+  },
+  {
+    value: 'weekly',
+    label: '주간 반복',
+  },
+  {
+    value: 'monthly',
+    label: '월간 반복',
+  },
+  {
+    value: 'yearly',
+    label: '연간 반복',
+  },
+]
 
-// const CustomPlaceholder = () => (
-//   <div>
-//     <span className="hidden sm:inline">반복</span>
-//     <span> 선택</span>
-//   </div>
-// )
+const dateString = (repeatType: RecurringOptionValue): string => {
+  switch (repeatType) {
+    case 'daily':
+      return '일'
+    case 'weekly':
+      return '주'
+    case 'monthly':
+      return '개월'
+    case 'yearly':
+      return '년'
+    default:
+      return ''
+  }
+}
 
-const RepetitionField = () => {
-  // const { isModalOpen, openModal, closeModal } = useModal()
-  const { watch } = useFormContext()
-  // const [selected, setSelected] = useState<string>('')
-  // const [repeatType, setRepeatType] = useState<RecurringOptionValue>('none')
+const CustomPlaceholder = () => (
+  <div>
+    <span className="hidden sm:inline">반복</span>
+    <span> 선택</span>
+  </div>
+)
 
-  // useEffect(() => {
-  //   setValue('isRecurring', true);
-  // }, [setValue])
+const RepetitionField = ({ isUpdateForm }: { isUpdateForm?: boolean }) => {
+  const { isModalOpen, openModal, closeModal } = useModal()
+  const { watch, setValue } = useFormContext()
+  const [selected, setSelected] = useState<string>('')
+  const [repeatType, setRepeatType] = useState<RecurringOptionValue>('none')
 
   const isRecurring = watch('isRecurring')
-  // const settedRepeatType = watch('repeatType')
+  const currentRecurringOptions = watch('recurringOptions')
+  const currentEndDate = watch('endDate')
+
+  useEffect(() => {
+    if (currentRecurringOptions?.recurringInterval) {
+      setSelected(
+        `${currentRecurringOptions.recurringInterval}${dateString(repeatType)} 간격 반복`
+      )
+    }
+  }, [repeatType, currentRecurringOptions?.recurringInterval])
 
   return (
     <>
       <div id="isRecurring" className="hidden">
         {isRecurring}
       </div>
-      {/* <div className="hidden">{settedRepeatType}</div>
+      {/* <div className="hidden">{currentRecurringOptions?.repeatType}</div> */}
       <BaseSection
-        id="repitition"
         label="반복"
-        renderInput={() => (
-          <div className="flex-growd">
-            <Select
-              aria-label="반복 선택"
-              options={options}
-              placeholder={<CustomPlaceholder />}
-              classNamePrefix="react-select"
-              className="select-placeholder"
-              menuPlacement="auto"
-              menuPosition="fixed"
-              components={{
-                Option: ({ ...props }) => (
-                  <components.Option {...props}>
-                    <div
-                      onClick={() => {
-                        openModal()
-                        setRepeatType(props.data.value)
-                        setValue('repeatType', props.data.value)
-                        setValue(
-                          'isRecurring',
-                          props.data.value === 'none' ? false : true
-                        )
-                      }}
-                    >
-                      {props.data.label}
-                    </div>
-                  </components.Option>
-                ),
-                SingleValue: () => (
-                  <div className="px-2 py-1 text-center sm:text-sm">
-                    {selected}
+      >
+        <div className="flex-growd">
+          <Select
+            aria-label="반복 선택"
+            options={options}
+            isDisabled={isUpdateForm}
+            placeholder={<CustomPlaceholder />}
+            classNamePrefix="react-select"
+            className="select-placeholder"
+            menuPlacement="auto"
+            menuPosition="fixed"
+            components={{
+              Option: ({ ...props }) => (
+                <components.Option {...props}>
+                  <div
+                    onClick={() => {
+                      openModal()
+                      setRepeatType(props.data.value)
+                      setValue(
+                        'isRecurring',
+                        props.data.value === 'none' ? false : true
+                      )
+                      setValue('recurringOptions', {
+                        repeatEndDate: addDays(currentEndDate, 31),
+                        recurringInterval: 1,
+                        repeatType: props.data.value
+                      })
+                    }}
+                  >
+                    {props.data.label}
                   </div>
-                ),
-              }}
-              styles={{
-                placeholder: (base) => ({
-                  ...base,
-                  fontSize: 'inherit',
-                  lineHeight: 'inherit',
-                }),
-                control: (base) => ({
-                  ...base,
-                  height: '36px',
-                  border: '1px solid #d1d5db',
-                  borderRadius: '0.375rem',
-                  boxShadow: 'none',
-                  width: 'auto',
-                  minWidth: '120px',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  '&:hover': {
-                    borderColor: '#9ca3af',
-                  },
-                }),
-                valueContainer: (base) => ({
-                  ...base,
-                  padding: '0 8px',
-                  display: 'flex',
-                }),
-                singleValue: (base) => ({
-                  ...base,
-                  margin: '0',
-                }),
-                input: (base) => ({
-                  ...base,
-                  margin: '0',
-                  padding: '0',
-                  caretColor: 'transparent',
-                }),
-                indicatorSeparator: () => ({
-                  display: 'none',
-                }),
-                dropdownIndicator: (base) => ({
-                  ...base,
-                  padding: '4px',
-                }),
-                option: (base) => ({
-                  ...base,
-                  color: '#000000',
-                  backgroundColor: 'transparent',
-                  cursor: 'pointer',
-                  '&:hover': {
-                    backgroundColor: '#f3f4f6',
-                  },
-                }),
-              }}
-            />
-          </div>
-        )}
-      />
+                </components.Option>
+              ),
+              SingleValue: () => (
+                <div className="px-2 py-1 text-center sm:text-sm">
+                  {selected}
+                </div>
+              ),
+            }}
+            styles={{
+              placeholder: (base) => ({
+                ...base,
+                fontSize: 'inherit',
+                lineHeight: 'inherit',
+              }),
+              control: (base) => ({
+                ...base,
+                height: '36px',
+                border: '1px solid #d1d5db',
+                borderRadius: '0.375rem',
+                boxShadow: 'none',
+                width: 'auto',
+                minWidth: '120px',
+                display: 'inline-flex',
+                alignItems: 'center',
+                '&:hover': {
+                  borderColor: '#9ca3af',
+                },
+              }),
+              valueContainer: (base) => ({
+                ...base,
+                padding: '0 8px',
+                display: 'flex',
+              }),
+              singleValue: (base) => ({
+                ...base,
+                margin: '0',
+              }),
+              input: (base) => ({
+                ...base,
+                margin: '0',
+                padding: '0',
+                caretColor: 'transparent',
+              }),
+              indicatorSeparator: () => ({
+                display: 'none',
+              }),
+              dropdownIndicator: (base) => ({
+                ...base,
+                padding: '4px',
+              }),
+              option: (base) => ({
+                ...base,
+                color: '#000000',
+                backgroundColor: 'transparent',
+                cursor: 'pointer',
+                '&:hover': {
+                  backgroundColor: '#f3f4f6',
+                },
+              }),
+            }}
+          />
+        </div>
+      </BaseSection>
 
       {isModalOpen && (
         <RepititionSetModal
@@ -160,7 +184,7 @@ const RepetitionField = () => {
           repeatType={repeatType}
           setSelected={setSelected}
         />
-      )} */}
+      )}
     </>
   )
 }

--- a/packages/client/src/components/common/schedule-form/field-components/RepetitionField.tsx
+++ b/packages/client/src/components/common/schedule-form/field-components/RepetitionField.tsx
@@ -66,7 +66,7 @@ const RepetitionField = ({ isUpdateForm }: { isUpdateForm?: boolean }) => {
         case 'monthly':
           return `${recurringInfo?.recurringInterval}개월 마다 ${recurringInfo?.recurringDayOfMonth && recurringInfo?.recurringDayOfMonth}일에 반복`
         case 'yearly':
-          return `${recurringInfo?.recurringInterval}년 마다 ${recurringInfo?.recurringMonthOfYear && recurringInfo?.recurringMonthOfYear}월에 반복`
+          return `${recurringInfo?.recurringInterval}년 마다 ${recurringInfo?.recurringMonthOfYear && recurringInfo?.recurringMonthOfYear + 1}월에 반복`
         default:
           return ''
       }

--- a/packages/client/src/components/common/schedule-form/field-components/RepetitionField.tsx
+++ b/packages/client/src/components/common/schedule-form/field-components/RepetitionField.tsx
@@ -35,21 +35,6 @@ const options: RecurringOption[] = [
   },
 ]
 
-const dateString = (repeatType: RecurringOptionValue): string => {
-  switch (repeatType) {
-    case 'daily':
-      return '일'
-    case 'weekly':
-      return '주'
-    case 'monthly':
-      return '개월'
-    case 'yearly':
-      return '년'
-    default:
-      return ''
-  }
-}
-
 const CustomPlaceholder = () => (
   <div>
     <span className="hidden sm:inline">반복</span>
@@ -60,27 +45,42 @@ const CustomPlaceholder = () => (
 const RepetitionField = ({ isUpdateForm }: { isUpdateForm?: boolean }) => {
   const { isModalOpen, openModal, closeModal } = useModal()
   const { watch, setValue } = useFormContext()
-  const [selected, setSelected] = useState<string>('')
-  const [repeatType, setRepeatType] = useState<RecurringOptionValue>('none')
 
-  const isRecurring = watch('isRecurring')
   const currentRecurringOptions = watch('recurringOptions')
   const currentEndDate = watch('endDate')
 
+  const [selected, setSelected] = useState<string>('')
+  const [repeatType, setRepeatType] = useState<RecurringOptionValue>(currentRecurringOptions?.repeatType ?? 'none')
+
   useEffect(() => {
-    if (currentRecurringOptions?.recurringInterval) {
+    const selectedDateString = (repeatType: RecurringOptionValue): string => {
+      const days = ['일', '월', '화', '수', '목', '금', '토']
+      const recurringInfo = currentRecurringOptions
+  
+      switch (repeatType) {
+        case 'daily':
+          return `${recurringInfo?.recurringInterval}일 마다 반복`;
+        case 'weekly':
+          return `${recurringInfo?.recurringInterval}주 마다 ${recurringInfo?.recurringDaysOfWeek?.map((idx: number) => days[idx].split(', '))} 요일에 반복
+          `;
+        case 'monthly':
+          return `${recurringInfo?.recurringInterval}개월 마다 ${recurringInfo?.recurringDayOfMonth && recurringInfo?.recurringDayOfMonth}일에 반복`
+        case 'yearly':
+          return `${recurringInfo?.recurringInterval}년 마다 ${recurringInfo?.recurringMonthOfYear && recurringInfo?.recurringMonthOfYear}월에 반복`
+        default:
+          return ''
+      }
+    }
+
+    if (currentRecurringOptions?.repeatType && currentRecurringOptions?.recurringInterval) {
       setSelected(
-        `${currentRecurringOptions.recurringInterval}${dateString(repeatType)} 간격 반복`
+        `${selectedDateString(currentRecurringOptions.repeatType)}`
       )
     }
-  }, [repeatType, currentRecurringOptions?.recurringInterval])
+  }, [currentRecurringOptions, currentRecurringOptions?.repeatType, currentRecurringOptions?.recurringInterval])
 
   return (
     <>
-      <div id="isRecurring" className="hidden">
-        {isRecurring}
-      </div>
-      {/* <div className="hidden">{currentRecurringOptions?.repeatType}</div> */}
       <BaseSection
         label="반복"
       >
@@ -94,6 +94,7 @@ const RepetitionField = ({ isUpdateForm }: { isUpdateForm?: boolean }) => {
             className="select-placeholder"
             menuPlacement="auto"
             menuPosition="fixed"
+            value={options.find(option => option.value === currentRecurringOptions?.repeatType) || null}
             components={{
               Option: ({ ...props }) => (
                 <components.Option {...props}>

--- a/packages/client/src/components/common/schedule-form/field-components/RepititionSetModal.tsx
+++ b/packages/client/src/components/common/schedule-form/field-components/RepititionSetModal.tsx
@@ -5,7 +5,6 @@ import { useFormContext } from 'react-hook-form'
 import Divider from '../../Divider'
 import 'react-datepicker/dist/react-datepicker.css'
 import './react-datepicker.css'
-// import DatePicker from 'react-datepicker'
 import { useState } from 'react'
 import { getDate, setDate, setMonth, setYear } from 'date-fns'
 import Picker from '../../Picker'
@@ -15,20 +14,6 @@ type Props = {
   setSelected: (selected: string) => void
 } & TModal
 
-// const CustomInput = React.forwardRef<
-//   HTMLDivElement,
-//   { value?: string; onClick?: () => void }
-// >(({ value, onClick }, ref) => (
-//   <div
-//     className="mt-1 flex cursor-pointer space-x-1"
-//     onClick={onClick}
-//     ref={ref}
-//   >
-//     <div className="w-28 rounded-lg bg-neutral-200 px-3 py-3 text-center text-xs text-neutral-700 sm:w-36 sm:py-2 sm:text-base">
-//       {value ? value.split(' ').slice(0, 3).join(' ') : '날짜 선택'}
-//     </div>
-//   </div>
-// ))
 
 const dateString = (repeatType: RecurringOptionValue): string => {
   switch (repeatType) {
@@ -54,7 +39,25 @@ const RepititionBottomComponent = ({
 
   const currentRecurringOptions = watch('recurringOptions')
   const repeatEndDate = currentRecurringOptions.repeatEndDate
-  const recurringInterval = currentRecurringOptions.recurringInterval
+
+  const selectedDateString = (repeatType: RecurringOptionValue): string => {
+    const days = ['일', '월', '화', '수', '목', '금', '토']
+    const recurringInfo = currentRecurringOptions
+
+    switch (repeatType) {
+      case 'daily':
+        return `${recurringInfo?.recurringInterval}일 마다 반복`;
+      case 'weekly':
+        return `${recurringInfo?.recurringInterval}주 마다 ${recurringInfo?.recurringDaysOfWeek?.map((idx: number) => days[idx].split(', '))}요일에 반복
+        `;
+      case 'monthly':
+        return `${recurringInfo?.recurringInterval}개월 마다 ${recurringInfo?.recurringDayOfMonth && recurringInfo?.recurringDayOfMonth}일에 반복`
+      case 'yearly':
+        return `${recurringInfo?.recurringInterval}년 마다 ${recurringInfo?.recurringMonthOfYear && recurringInfo?.recurringMonthOfYear}월에 반복`
+      default:
+        return ''
+    }
+  }
 
   const generateColumns = () => {
     const currentYear = new Date().getFullYear() - 10
@@ -148,16 +151,6 @@ const RepititionBottomComponent = ({
                 placeholder="날짜 선택"
                 title="날짜 선택"
               />
-              {/* <DatePicker
-                selected={field.value}
-                onChange={(date) => setValue('repeatEndDate', date)}
-                timeFormat="HH:mm"
-                timeCaption="시간"
-                locale="ko"
-                dateFormat={'yyyy. MM. dd.'}
-                customInput={<CustomInput />}
-                calendarClassName="custom-datepicker"
-              /> */}
             </div>
         </div>
       </div>
@@ -165,7 +158,7 @@ const RepititionBottomComponent = ({
         <button
           onClick={() => {
             setSelected(
-              `${recurringInterval}${dateString(repeatType)} 간격 반복`,
+              `${selectedDateString(repeatType)}`,
             )
             onClose()
           }}

--- a/packages/client/src/components/common/schedule-form/field-components/RepititionSetModal.tsx
+++ b/packages/client/src/components/common/schedule-form/field-components/RepititionSetModal.tsx
@@ -1,32 +1,34 @@
 import { RecurringOptionValue } from '@/types/schedules'
 import Modal from '../../Modal'
 import { TModal } from '@/types/common'
-import { Controller, useFormContext } from 'react-hook-form'
+import { useFormContext } from 'react-hook-form'
 import Divider from '../../Divider'
 import 'react-datepicker/dist/react-datepicker.css'
 import './react-datepicker.css'
-import DatePicker from 'react-datepicker'
-import React, { useState } from 'react'
+// import DatePicker from 'react-datepicker'
+import { useState } from 'react'
+import { getDate, setDate, setMonth, setYear } from 'date-fns'
+import Picker from '../../Picker'
 
 type Props = {
   repeatType: RecurringOptionValue
   setSelected: (selected: string) => void
 } & TModal
 
-const CustomInput = React.forwardRef<
-  HTMLDivElement,
-  { value?: string; onClick?: () => void }
->(({ value, onClick }, ref) => (
-  <div
-    className="mt-1 flex cursor-pointer space-x-1"
-    onClick={onClick}
-    ref={ref}
-  >
-    <div className="w-28 rounded-lg bg-neutral-200 px-3 py-3 text-center text-xs text-neutral-700 sm:w-36 sm:py-2 sm:text-base">
-      {value ? value.split(' ').slice(0, 3).join(' ') : '날짜 선택'}
-    </div>
-  </div>
-))
+// const CustomInput = React.forwardRef<
+//   HTMLDivElement,
+//   { value?: string; onClick?: () => void }
+// >(({ value, onClick }, ref) => (
+//   <div
+//     className="mt-1 flex cursor-pointer space-x-1"
+//     onClick={onClick}
+//     ref={ref}
+//   >
+//     <div className="w-28 rounded-lg bg-neutral-200 px-3 py-3 text-center text-xs text-neutral-700 sm:w-36 sm:py-2 sm:text-base">
+//       {value ? value.split(' ').slice(0, 3).join(' ') : '날짜 선택'}
+//     </div>
+//   </div>
+// ))
 
 const dateString = (repeatType: RecurringOptionValue): string => {
   switch (repeatType) {
@@ -48,9 +50,59 @@ const RepititionBottomComponent = ({
   setSelected,
   onClose,
 }: Props) => {
-  const { register, control, setValue, watch } = useFormContext()
+  const { register, setValue, watch } = useFormContext()
 
-  const recurringInterval = watch('recurringInterval')
+  const currentRecurringOptions = watch('recurringOptions')
+  const repeatEndDate = currentRecurringOptions.repeatEndDate
+  const recurringInterval = currentRecurringOptions.recurringInterval
+
+  const generateColumns = () => {
+    const currentYear = new Date().getFullYear() - 10
+
+    return [
+      {
+        name: 'year',
+        options: Array.from({ length: 20 }, (_, i) => ({
+          value: (currentYear + i).toString(),
+          label: `${currentYear + i}년`,
+        })),
+      },
+      {
+        name: 'month',
+        options: Array.from({ length: 12 }, (_, i) => ({
+          value: i.toString(),
+          label: `${i + 1}월`,
+        })),
+      },
+      {
+        name: 'day',
+        options: Array.from(
+          {
+            length: new Date(
+              repeatEndDate.getFullYear(),
+              repeatEndDate.getMonth() + 1,
+              0,
+            ).getDate(),
+          },
+          (_, i) => ({
+            value: (i + 1).toString(),
+            label: `${i + 1}일`,
+          }),
+        ),
+      },
+    ]
+  }
+
+  const handleChange = ([yearStr, monthStr, dayStr]: string[]) => {
+    const newDate = setDate(
+      setMonth(setYear(repeatEndDate, parseInt(yearStr)), parseInt(monthStr)),
+      parseInt(dayStr),
+    )
+    setValue('recurringOptions', {
+      ...currentRecurringOptions,
+      repeatEndDate: newDate
+    })
+  }
 
   return (
     <div className="pt-3">
@@ -58,9 +110,10 @@ const RepititionBottomComponent = ({
         <input
           className="h-7 w-14 rounded border bg-neutral-300 py-2 pl-4 pr-3 outline-none sm:h-10 sm:w-20 sm:w-24"
           type="number"
-          min="1"
-          step="1"
-          {...register('recurringInterval', {
+          min={1}
+          step={1}
+          {...register('recurringOptions.recurringInterval', {
+            valueAsNumber: true,
             min: {
               value: 1,
               message: '1 이상의 숫자를 입력해주세요.',
@@ -83,24 +136,29 @@ const RepititionBottomComponent = ({
             <span>반복 종료</span>
             <span className="hidden sm:inline"> 일자</span>
           </label>
-          <Controller
-            name="repeatEndDate"
-            control={control}
-            render={({ field }) => (
-              <div className="relative w-60 text-right">
-                <DatePicker
-                  selected={field.value}
-                  onChange={(date) => setValue('repeatEndDate', date)}
-                  timeFormat="HH:mm"
-                  timeCaption="시간"
-                  locale="ko"
-                  dateFormat={'yyyy. MM. dd.'}
-                  customInput={<CustomInput />}
-                  calendarClassName="custom-datepicker"
-                />
-              </div>
-            )}
-          />
+            <div className="relative w-60 text-right">
+              <Picker
+                columns={generateColumns()}
+                values={[
+                  repeatEndDate.getFullYear().toString(),
+                  repeatEndDate.getMonth().toString(),
+                  repeatEndDate.getDate().toString(),
+                ]}
+                onChange={handleChange}
+                placeholder="날짜 선택"
+                title="날짜 선택"
+              />
+              {/* <DatePicker
+                selected={field.value}
+                onChange={(date) => setValue('repeatEndDate', date)}
+                timeFormat="HH:mm"
+                timeCaption="시간"
+                locale="ko"
+                dateFormat={'yyyy. MM. dd.'}
+                customInput={<CustomInput />}
+                calendarClassName="custom-datepicker"
+              /> */}
+            </div>
         </div>
       </div>
       <div className="mt-4 flex justify-center">
@@ -121,14 +179,30 @@ const RepititionBottomComponent = ({
 }
 
 const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
-  const [weekDaySelected, setWeekDaySelected] = useState<string[]>([])
-  const [daysSelected, setDaysSelected] = useState<number>(0)
-  const [monthSelected, setMonthSelected] = useState<number>(0)
+  const { watch, setValue } = useFormContext()
 
-  const toggleWeekday = (idx: string) => {
+  const currentStartDate = watch('startDate')
+  const currentRecurringOptions = watch('recurringOptions')
+
+  const [weekDaySelected, setWeekDaySelected] = useState<number[]>([0])
+  const [daysSelected, setDaysSelected] = useState<number>(1)
+  const [monthSelected, setMonthSelected] = useState<number>(1)
+
+  const toggleWeekday = (idx: number) => {
     if (setWeekDaySelected) {
-      setWeekDaySelected((prev) =>
-        prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx],
+      setValue('recurringOptions', {
+        ...currentRecurringOptions,
+        recurringDaysOfWeek: [0],
+      })
+      setWeekDaySelected((prev) => {
+        const newSelected = prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+
+        setValue('recurringOptions', {
+          ...currentRecurringOptions,
+          recurringDaysOfWeek: newSelected,
+        })
+        return newSelected
+      },
       )
     }
   }
@@ -138,7 +212,8 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
     return null
   }
 
-  if (repeatType === 'daily')
+  if (repeatType === 'daily') {
+
     return (
       <>
         <Modal onClose={onClose} title="일간 반복 설정">
@@ -153,8 +228,17 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
         </Modal>
       </>
     )
+  }
 
-  if (repeatType === 'weekly')
+  if (repeatType === 'weekly') {
+
+    if (!currentRecurringOptions?.recurringDaysOfWeek) {
+      setValue('recurringOptions', {
+        ...currentRecurringOptions,
+        recurringDaysOfWeek: [0],
+      })
+    }
+
     return (
       <>
         <Modal onClose={onClose} title="주간 반복 설정">
@@ -163,14 +247,15 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
               <div className="mx-auto text-sm sm:text-base">
                 🍀 매주 일정 반복 요일 선택
               </div>
+              <div className="mx-auto text-xs mt-2 text-neutral-500">하나 이상의 요일을 선택해주세요</div>
               <div className="mx-auto my-3 flex gap-2">
                 {['일', '월', '화', '수', '목', '금', '토'].map(
                   (weekday, idx) => (
                     <button
                       key={idx}
-                      onClick={() => toggleWeekday(idx.toString())}
+                      onClick={() => toggleWeekday(idx)}
                       className={`w-6 rounded py-1 text-center text-sm sm:w-7 sm:text-base ${
-                        weekDaySelected.includes(idx.toString())
+                        weekDaySelected.includes(idx)
                           ? 'bg-primary-500 text-white'
                           : 'bg-neutral-300'
                       }`}
@@ -191,8 +276,17 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
         </Modal>
       </>
     )
+  }
 
-  if (repeatType === 'monthly')
+  if (repeatType === 'monthly') {
+
+    if (!currentRecurringOptions?.recurringDayOfMonth) {
+      setValue('recurringOptions', {
+        ...currentRecurringOptions,
+        recurringDayOfMonth: 1,
+      })
+    }
+
     return (
       <>
         <Modal onClose={onClose} title="월간 반복 설정">
@@ -204,7 +298,13 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
               {Array.from({ length: 31 }, (_, i) => i + 1).map((date) => (
                 <button
                   key={date}
-                  onClick={() => setDaysSelected(date)}
+                  onClick={() => {
+                    setDaysSelected(date)
+                    setValue('recurringOptions', {
+                      ...currentRecurringOptions,
+                      recurringDayOfMonth: date,
+                    })
+                  }}
                   className={`w-8 rounded p-2 text-center text-sm sm:w-10 sm:text-base ${
                     daysSelected === date
                       ? 'bg-primary-500 text-white'
@@ -224,20 +324,36 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
         </Modal>
       </>
     )
+  }
 
-  if (repeatType === 'yearly')
+  if (repeatType === 'yearly') {
+
+    if (!currentRecurringOptions?.recurringMonthOfYear) {
+      setValue('recurringOptions', {
+        ...currentRecurringOptions,
+        recurringMonthOfYear: 1,
+        recurringDayOfMonth: getDate(currentStartDate)
+      })
+    }
+
     return (
       <>
         <Modal onClose={onClose} title="연간 반복 설정">
           <div className="p-4">
             <div className="px-6 text-base text-sm">
-              🍀 매년 일정 반복 날짜 선택
+              🍀 매년 일정 반복 월 선택
             </div>
             <div className="mb-4 mt-4 grid grid-cols-7 gap-1 px-6">
               {Array.from({ length: 12 }, (_, i) => i + 1).map((date) => (
                 <button
                   key={date}
-                  onClick={() => setMonthSelected(date)}
+                  onClick={() => {
+                    setMonthSelected(date)
+                    setValue('recurringOptions', {
+                      ...currentRecurringOptions,
+                      recurringMonthOfYear: date
+                    })
+                  }}
                   className={`w-8 rounded p-2 text-center text-sm sm:w-10 sm:text-base ${
                     monthSelected === date
                       ? 'bg-primary-500 text-white'
@@ -257,6 +373,7 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
         </Modal>
       </>
     )
+  }
 }
 
 export default RepititionSetModal

--- a/packages/client/src/components/common/schedule-form/field-components/RepititionSetModal.tsx
+++ b/packages/client/src/components/common/schedule-form/field-components/RepititionSetModal.tsx
@@ -344,7 +344,7 @@ const RepititionSetModal = ({ repeatType, onClose, setSelected }: Props) => {
                     setMonthSelected(date)
                     setValue('recurringOptions', {
                       ...currentRecurringOptions,
-                      recurringMonthOfYear: date
+                      recurringMonthOfYear: date - 1
                     })
                   }}
                   className={`w-8 rounded p-2 text-center text-sm sm:w-10 sm:text-base ${

--- a/packages/client/src/pages/ScheduleDetailPage.tsx
+++ b/packages/client/src/pages/ScheduleDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   IPartialScheduleForm,
   UpdateScheduleReq,
   UpdateScheduleRes,
+  RecurringOptionValue,
 } from '@/types/schedules'
 import { formatDate } from '@/utils/format-date'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -93,6 +94,25 @@ const ScheduleDetailPage = () => {
     queryKey: [QUERY_KEYS.GET_SCHEDULE_BY_ID, isUpdate],
     queryFn: () => getScheduleById(id as string),
   })
+
+  const dateString = (repeatType: RecurringOptionValue): string => {
+    const days = ['일', '월', '화', '수', '목', '금', '토']
+    const recurringInfo = data?.recurringInfo
+
+    switch (repeatType) {
+      case 'daily':
+        return `${recurringInfo?.interval}일 마다 반복`;
+      case 'weekly':
+        return `${recurringInfo?.interval}주 마다 ${recurringInfo?.daysOfWeek?.map((idx) => days[idx].split(', '))} 요일에 반복
+        `;
+      case 'monthly':
+        return `${recurringInfo?.interval}개월 마다 ${recurringInfo?.dayOfMonth && recurringInfo?.dayOfMonth}일에 반복`
+      case 'yearly':
+        return `${recurringInfo?.interval}년 마다 ${recurringInfo?.monthOfYear && recurringInfo?.monthOfYear}월에 반복`
+      default:
+        return ''
+    }
+  }
 
   if (isLoading) return <div>로딩 중...</div>
   if (!data) return <div>데이터가 없습니다.</div>
@@ -257,11 +277,18 @@ const ScheduleDetailPage = () => {
                             </div>
                           </div>
                         ))}
+
                       </div>
                     ))}
                   </>
                 </div>
               )}
+              {data.recurringInfo && data.recurringInfo.repeatType && data.recurringInfo.repeatType !== "none" && (
+                <InfoItem
+                label="반복"
+                content={dateString(data.recurringInfo.repeatType)}
+              />
+              )} 
             </div>
           </div>
         </div>
@@ -286,6 +313,7 @@ const ScheduleDetailPage = () => {
             defaultValue={data}
             onSubmit={handleUpdateSchedule}
             buttonMessage="수정하기"
+            isUpdateForm
           />
         </div>
       )}

--- a/packages/client/src/pages/create-schedule/CreateManualSchedulePage.tsx
+++ b/packages/client/src/pages/create-schedule/CreateManualSchedulePage.tsx
@@ -7,7 +7,7 @@ import { createManualScheduleSteps } from '@/constants/schedules'
 import { useUser } from '@/hooks/use-user'
 import { CreateScheduleStepEnum } from '@/types/common'
 import {
-  IPartialScheduleForm,
+  // IPartialScheduleForm,
   PostSchedulesReq,
   PostSchedulesRes,
 } from '@/types/schedules'
@@ -33,12 +33,12 @@ const CreateManualSchedulePage = () => {
     mutationFn: postSchedules,
   })
 
-  const handleSubmit = (data: IPartialScheduleForm) => {
+  const handleSubmit = (data: PostSchedulesReq) => {
     if (!user?.info?.userUuid) return
 
     const payload = {
       ...data,
-    } as PostSchedulesReq
+    }
 
     mutation.mutate(payload, {
       onSuccess: (response) => {

--- a/packages/client/src/pages/create-schedule/CreateManualSchedulePage.tsx
+++ b/packages/client/src/pages/create-schedule/CreateManualSchedulePage.tsx
@@ -7,7 +7,6 @@ import { createManualScheduleSteps } from '@/constants/schedules'
 import { useUser } from '@/hooks/use-user'
 import { CreateScheduleStepEnum } from '@/types/common'
 import {
-  // IPartialScheduleForm,
   PostSchedulesReq,
   PostSchedulesRes,
 } from '@/types/schedules'

--- a/packages/client/src/types/schedules.ts
+++ b/packages/client/src/types/schedules.ts
@@ -35,6 +35,7 @@ export interface IRepeatInfo {
   recurringDaysOfWeek?: number[] | null
   recurringDayOfMonth?: number | null
   recurringMonthOfYear?: number | null
+  repeatType?: RecurringOptionValue
   // groupInfo?: Array<IGroupReq>
 }
 

--- a/packages/client/src/types/schedules.ts
+++ b/packages/client/src/types/schedules.ts
@@ -38,6 +38,15 @@ export interface IRepeatInfo {
   // groupInfo?: Array<IGroupReq>
 }
 
+export interface IRepeatInfoRes {
+  dayOfMonth?: number | null
+  daysOfWeek?: number[] | null
+  interval?: number
+  monthOfYear?: number | null
+  repeatEndDate?: Date
+  repeatType?: RecurringOptionValue
+}
+
 export interface ISchedule extends IRepeatInfo {
   scheduleId: number
   userUuid: string
@@ -50,6 +59,7 @@ export interface ISchedule extends IRepeatInfo {
   category: ICategory
   isRecurring: boolean;
   groupInfo?: Array<IGroupRes>
+  recurringInfo?: IRepeatInfoRes
 }
 
 export interface IMediaAnalysisResult extends IRepeatInfo {
@@ -84,10 +94,8 @@ export interface IPartialScheduleForm extends IRepeatInfo {
   isAllDay: boolean
   categoryId: number
   isRecurring: boolean
-  repeatType: RecurringOptionValue
+  recurringOptions: IRepeatInfo
   groupInfo?: Array<IGroupReq>
-  addGroupInfo?: Array<IGroupReq>;
-  deleteGroupInfo?: Array<IGroupReq>;
 }
 
 export interface PostSchedulesReq extends IRepeatInfo {


### PR DESCRIPTION
## 🔗 이슈 번호
#73 

## ✅ 작업 내용
- 일정 등록 시, 일간 주간 월간 연간 반복 기능 모두 연결하였습니다.

- 일간 일정 반복
<img src="https://github.com/user-attachments/assets/5eaaa479-7e98-47a3-af43-6f9f6bc87a29" width="300">

- 주간 일정 반복
<img src="https://github.com/user-attachments/assets/a46ab378-136c-4330-b8c3-0e2f7718a838" width="300">

- 월간 일정 반복
<img src="https://github.com/user-attachments/assets/513fa22e-348e-4bf6-a9ab-4be76fd70c3a" width="300">

- 연간 일정 반복
<img src="https://github.com/user-attachments/assets/5eff9b47-c568-43e3-b9ce-eee367aa1b67" width="300">

## 🗣️ 공유 사항
- 현재, 반복 일정으로 등록된 일정에 대해 수정이 진행되지 않습니다. 
```
{
    "message": "지정된 날짜 Invalid Date는 이 반복 일정의 유효한 날짜가 아닙니다.",
    "error": "Bad Request",
    "statusCode": 400
}
```
우선 일정 수정시에, 기존 설정해둔 반복 설정에 대해 수정 불가능 하도록 막아두었습니다. 
하지만, 반복 일정의 경우 제목 등의 수정사항에 대해서도 동일한 에러 statusCode가 반환되어서 이 부분에 대해서는 연결 완료하지 못했습니다.
@nullisdefined 
