### PR TITLE
[FE] 에러 처리 파일 획일화

### DIFF
--- a/packages/server/src/common/exception/business.exception.ts
+++ b/packages/server/src/common/exception/business.exception.ts
@@ -1,0 +1,99 @@
+import { HttpException } from '@nestjs/common'
+import {
+  ErrorCode,
+  ErrorHttpStatusMap,
+  ErrorMessageMap,
+} from './error-codes.enum'
+import { ErrorDetails } from './error-response.dto'
+
+export class BusinessException extends HttpException {
+  private readonly errorCode: ErrorCode
+  private readonly details?: ErrorDetails
+  private readonly timestamp: string
+
+  /**
+   * 비즈니스 예외 생성자
+   * @param errorCode 서비스 에러 코드
+   * @param message 사용자 정의 에러 메시지 (제공하지 않으면 기본 메시지 사용)
+   * @param details 상세 에러 정보
+   */
+  constructor(errorCode: ErrorCode, message?: string, details?: ErrorDetails) {
+    // ErrorHttpStatusMap에서 HTTP 상태 코드를 가져오거나 기본값으로 INTERNAL_SERVER_ERROR 사용
+    const statusCode = ErrorHttpStatusMap[errorCode] || 500
+
+    // 메시지가 제공되지 않았다면 기본 에러 메시지 맵에서 가져옴
+    const errorMessage =
+      message || ErrorMessageMap[errorCode] || '알 수 없는 오류가 발생했습니다.'
+
+    // HttpException 생성자 호출
+    super(errorMessage, statusCode)
+
+    this.errorCode = errorCode
+    this.details = details
+    this.timestamp = new Date().toISOString()
+
+    // 프로토타입 체인 유지를 위한 설정
+    Object.setPrototypeOf(this, BusinessException.prototype)
+  }
+
+  /**
+   * 비즈니스 예외의 응답 객체를 가져오는 메서드
+   */
+  getErrorResponse(): {
+    statusCode: number
+    errorCode: ErrorCode
+    message: string
+    timestamp: string
+    details?: ErrorDetails
+  } {
+    return {
+      statusCode: this.getStatus(),
+      errorCode: this.errorCode,
+      message: this.message,
+      timestamp: this.timestamp,
+      ...(this.details && { details: this.details }),
+    }
+  }
+
+  /**
+   * ErrorCode 접근자
+   */
+  getErrorCode(): ErrorCode {
+    return this.errorCode
+  }
+
+  /**
+   * details 접근자
+   */
+  getDetails(): ErrorDetails | undefined {
+    return this.details
+  }
+
+  /**
+   * timestamp 접근자
+   */
+  getTimestamp(): string {
+    return this.timestamp
+  }
+
+  /**
+   * 특정 서비스 에러코드에 대한 비즈니스 예외를 생성하는 정적 팩토리 메서드
+   */
+  static fromCode(
+    errorCode: ErrorCode,
+    details?: ErrorDetails,
+  ): BusinessException {
+    return new BusinessException(errorCode, undefined, details)
+  }
+
+  /**
+   * 사용자 정의 메시지를 가진 비즈니스 예외를 생성하는 정적 팩토리 메서드
+   */
+  static fromMessage(
+    errorCode: ErrorCode,
+    message: string,
+    details?: ErrorDetails,
+  ): BusinessException {
+    return new BusinessException(errorCode, message, details)
+  }
+}

--- a/packages/server/src/common/exception/error-codes.enum.ts
+++ b/packages/server/src/common/exception/error-codes.enum.ts
@@ -1,0 +1,95 @@
+import { HttpStatus } from '@nestjs/common'
+
+/**
+ * 서비스 에러 코드 형식:
+ * - 첫 글자: 서비스 영역 (G: 글로벌, A: 인증/인가, U: 사용자, S: 스케줄, P: 결제, N: 알림 등)
+ * - 세 자리 숫자: 해당 서비스 내의 에러 번호
+ */
+export enum ErrorCode {
+  // 글로벌/시스템 관련 에러 (G000 ~ G999)
+  G000 = 'G000', // 알 수 없는 시스템 에러
+  G001 = 'G001', // 예상치 못한 에러
+  G002 = 'G002', // 데이터베이스 에러
+  G003 = 'G003', // 외부 API 에러
+
+  // 인증/인가 관련 에러 (A000 ~ A999)
+  A000 = 'A000', // 일반 인증 에러
+  A001 = 'A001', // 유효하지 않은 토큰
+  A002 = 'A002', // 토큰 만료
+  A003 = 'A003', // 권한 부족
+
+  // 사용자 관련 에러 (U000 ~ U999)
+  U000 = 'U000', // 일반 사용자 에러
+  U001 = 'U001', // 사용자 없음
+  U002 = 'U002', // 중복된 사용자
+
+  // 스케줄 관련 에러 (S000 ~ S999)
+  S000 = 'S000', // 일반 스케줄 에러
+  S001 = 'S001', // 스케줄 없음
+  S002 = 'S002', // 중복된 스케줄
+
+  // 입력값 검증 관련 에러 (V000 ~ V999)
+  V000 = 'V000', // 일반 검증 에러
+  V001 = 'V001', // 유효하지 않은 입력
+  V002 = 'V002', // 필수 필드 누락
+}
+
+// HTTP 상태 코드와 에러 코드 매핑
+export const ErrorHttpStatusMap: Record<ErrorCode, HttpStatus> = {
+  // 글로벌/시스템 관련 에러
+  [ErrorCode.G000]: HttpStatus.INTERNAL_SERVER_ERROR,
+  [ErrorCode.G001]: HttpStatus.INTERNAL_SERVER_ERROR,
+  [ErrorCode.G002]: HttpStatus.INTERNAL_SERVER_ERROR,
+  [ErrorCode.G003]: HttpStatus.BAD_GATEWAY,
+
+  // 인증/인가 관련 에러
+  [ErrorCode.A000]: HttpStatus.UNAUTHORIZED,
+  [ErrorCode.A001]: HttpStatus.UNAUTHORIZED,
+  [ErrorCode.A002]: HttpStatus.UNAUTHORIZED,
+  [ErrorCode.A003]: HttpStatus.FORBIDDEN,
+
+  // 사용자 관련 에러
+  [ErrorCode.U000]: HttpStatus.BAD_REQUEST,
+  [ErrorCode.U001]: HttpStatus.NOT_FOUND,
+  [ErrorCode.U002]: HttpStatus.CONFLICT,
+
+  // 스케줄 관련 에러
+  [ErrorCode.S000]: HttpStatus.BAD_REQUEST,
+  [ErrorCode.S001]: HttpStatus.NOT_FOUND,
+  [ErrorCode.S002]: HttpStatus.CONFLICT,
+
+  // 입력값 검증 관련 에러
+  [ErrorCode.V000]: HttpStatus.BAD_REQUEST,
+  [ErrorCode.V001]: HttpStatus.BAD_REQUEST,
+  [ErrorCode.V002]: HttpStatus.BAD_REQUEST,
+}
+
+// 에러 메시지 매핑
+export const ErrorMessageMap: Record<ErrorCode, string> = {
+  // 글로벌/시스템 관련 에러
+  [ErrorCode.G000]: '시스템 오류가 발생했습니다.',
+  [ErrorCode.G001]: '예상치 못한 오류가 발생했습니다.',
+  [ErrorCode.G002]: '데이터베이스 오류가 발생했습니다.',
+  [ErrorCode.G003]: '외부 API 호출 중 오류가 발생했습니다.',
+
+  // 인증/인가 관련 에러
+  [ErrorCode.A000]: '인증이 필요합니다.',
+  [ErrorCode.A001]: '유효하지 않은 토큰입니다.',
+  [ErrorCode.A002]: '토큰이 만료되었습니다.',
+  [ErrorCode.A003]: '접근 권한이 없습니다.',
+
+  // 사용자 관련 에러
+  [ErrorCode.U000]: '사용자 관련 오류가 발생했습니다.',
+  [ErrorCode.U001]: '사용자를 찾을 수 없습니다.',
+  [ErrorCode.U002]: '이미 존재하는 사용자입니다.',
+
+  // 스케줄 관련 에러
+  [ErrorCode.S000]: '스케줄 관련 오류가 발생했습니다.',
+  [ErrorCode.S001]: '스케줄을 찾을 수 없습니다.',
+  [ErrorCode.S002]: '중복된 스케줄이 존재합니다.',
+
+  // 입력값 검증 관련 에러
+  [ErrorCode.V000]: '입력값 검증에 실패했습니다.',
+  [ErrorCode.V001]: '유효하지 않은 입력값입니다.',
+  [ErrorCode.V002]: '필수 필드가 누락되었습니다.',
+}

--- a/packages/server/src/common/exception/error-codes.enum.ts
+++ b/packages/server/src/common/exception/error-codes.enum.ts
@@ -1,95 +1,140 @@
 import { HttpStatus } from '@nestjs/common'
 
-/**
- * 서비스 에러 코드 형식:
- * - 첫 글자: 서비스 영역 (G: 글로벌, A: 인증/인가, U: 사용자, S: 스케줄, P: 결제, N: 알림 등)
- * - 세 자리 숫자: 해당 서비스 내의 에러 번호
- */
-export enum ErrorCode {
-  // 글로벌/시스템 관련 에러 (G000 ~ G999)
-  G000 = 'G000', // 알 수 없는 시스템 에러
-  G001 = 'G001', // 예상치 못한 에러
-  G002 = 'G002', // 데이터베이스 에러
-  G003 = 'G003', // 외부 API 에러
+export class ErrorCode {
+  // 생성자로 필요한 정보를 받음
+  constructor(
+    readonly status: HttpStatus,
+    readonly code: string,
+    readonly message: string,
+  ) {}
 
-  // 인증/인가 관련 에러 (A000 ~ A999)
-  A000 = 'A000', // 일반 인증 에러
-  A001 = 'A001', // 유효하지 않은 토큰
-  A002 = 'A002', // 토큰 만료
-  A003 = 'A003', // 권한 부족
+  /**
+   * Common Errors (C로 시작)
+   */
+  static readonly INVALID_INPUT_VALUE = new ErrorCode(
+    HttpStatus.BAD_REQUEST,
+    'C001',
+    '잘못된 입력값입니다.',
+  )
+  static readonly INTERNAL_SERVER_ERROR = new ErrorCode(
+    HttpStatus.INTERNAL_SERVER_ERROR,
+    'C002',
+    '서버 에러가 발생했습니다.',
+  )
+  static readonly RESOURCE_NOT_FOUND = new ErrorCode(
+    HttpStatus.NOT_FOUND,
+    'C003',
+    '요청한 리소스를 찾을 수 없습니다.',
+  )
+  static readonly METHOD_NOT_ALLOWED = new ErrorCode(
+    HttpStatus.METHOD_NOT_ALLOWED,
+    'C004',
+    '허용되지 않은 메서드입니다.',
+  )
+  static readonly INVALID_TYPE_VALUE = new ErrorCode(
+    HttpStatus.BAD_REQUEST,
+    'C005',
+    '잘못된 타입의 값입니다.',
+  )
+  static readonly HANDLE_ACCESS_DENIED = new ErrorCode(
+    HttpStatus.FORBIDDEN,
+    'C006',
+    '접근이 거부되었습니다.',
+  )
 
-  // 사용자 관련 에러 (U000 ~ U999)
-  U000 = 'U000', // 일반 사용자 에러
-  U001 = 'U001', // 사용자 없음
-  U002 = 'U002', // 중복된 사용자
+  /**
+   * Authentication Errors (A로 시작)
+   */
+  static readonly UNAUTHORIZED = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'A001',
+    '인증이 필요합니다.',
+  )
+  static readonly INVALID_CREDENTIALS = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'A002',
+    '잘못된 인증 정보입니다.',
+  )
+  static readonly ACCOUNT_LOCKED = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'A003',
+    '계정이 잠겼습니다.',
+  )
 
-  // 스케줄 관련 에러 (S000 ~ S999)
-  S000 = 'S000', // 일반 스케줄 에러
-  S001 = 'S001', // 스케줄 없음
-  S002 = 'S002', // 중복된 스케줄
+  /**
+   * JWT Token Errors (J로 시작)
+   */
+  static readonly JWT_SIGNATURE_INVALID = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'J001',
+    '유효하지 않은 JWT 서명입니다.',
+  )
+  static readonly JWT_TOKEN_EXPIRED = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'J002',
+    '만료된 JWT 토큰입니다.',
+  )
+  static readonly JWT_TOKEN_UNSUPPORTED = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'J003',
+    '지원되지 않는 JWT 토큰 형식입니다.',
+  )
+  static readonly JWT_TOKEN_MALFORMED = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'J004',
+    '잘못된 형식의 JWT 토큰입니다.',
+  )
+  static readonly JWT_TOKEN_MISSING = new ErrorCode(
+    HttpStatus.UNAUTHORIZED,
+    'J005',
+    'JWT 토큰이 제공되지 않았습니다.',
+  )
 
-  // 입력값 검증 관련 에러 (V000 ~ V999)
-  V000 = 'V000', // 일반 검증 에러
-  V001 = 'V001', // 유효하지 않은 입력
-  V002 = 'V002', // 필수 필드 누락
-}
+  /**
+   * User Errors (U로 시작)
+   */
+  static readonly USER_NOT_FOUND = new ErrorCode(
+    HttpStatus.NOT_FOUND,
+    'U001',
+    '사용자를 찾을 수 없습니다.',
+  )
+  static readonly USER_ALREADY_EXISTS = new ErrorCode(
+    HttpStatus.CONFLICT,
+    'U002',
+    '이미 존재하는 사용자입니다.',
+  )
+  static readonly USER_EMAIL_DUPLICATED = new ErrorCode(
+    HttpStatus.CONFLICT,
+    'U003',
+    '이미 사용 중인 이메일입니다.',
+  )
 
-// HTTP 상태 코드와 에러 코드 매핑
-export const ErrorHttpStatusMap: Record<ErrorCode, HttpStatus> = {
-  // 글로벌/시스템 관련 에러
-  [ErrorCode.G000]: HttpStatus.INTERNAL_SERVER_ERROR,
-  [ErrorCode.G001]: HttpStatus.INTERNAL_SERVER_ERROR,
-  [ErrorCode.G002]: HttpStatus.INTERNAL_SERVER_ERROR,
-  [ErrorCode.G003]: HttpStatus.BAD_GATEWAY,
-
-  // 인증/인가 관련 에러
-  [ErrorCode.A000]: HttpStatus.UNAUTHORIZED,
-  [ErrorCode.A001]: HttpStatus.UNAUTHORIZED,
-  [ErrorCode.A002]: HttpStatus.UNAUTHORIZED,
-  [ErrorCode.A003]: HttpStatus.FORBIDDEN,
-
-  // 사용자 관련 에러
-  [ErrorCode.U000]: HttpStatus.BAD_REQUEST,
-  [ErrorCode.U001]: HttpStatus.NOT_FOUND,
-  [ErrorCode.U002]: HttpStatus.CONFLICT,
-
-  // 스케줄 관련 에러
-  [ErrorCode.S000]: HttpStatus.BAD_REQUEST,
-  [ErrorCode.S001]: HttpStatus.NOT_FOUND,
-  [ErrorCode.S002]: HttpStatus.CONFLICT,
-
-  // 입력값 검증 관련 에러
-  [ErrorCode.V000]: HttpStatus.BAD_REQUEST,
-  [ErrorCode.V001]: HttpStatus.BAD_REQUEST,
-  [ErrorCode.V002]: HttpStatus.BAD_REQUEST,
-}
-
-// 에러 메시지 매핑
-export const ErrorMessageMap: Record<ErrorCode, string> = {
-  // 글로벌/시스템 관련 에러
-  [ErrorCode.G000]: '시스템 오류가 발생했습니다.',
-  [ErrorCode.G001]: '예상치 못한 오류가 발생했습니다.',
-  [ErrorCode.G002]: '데이터베이스 오류가 발생했습니다.',
-  [ErrorCode.G003]: '외부 API 호출 중 오류가 발생했습니다.',
-
-  // 인증/인가 관련 에러
-  [ErrorCode.A000]: '인증이 필요합니다.',
-  [ErrorCode.A001]: '유효하지 않은 토큰입니다.',
-  [ErrorCode.A002]: '토큰이 만료되었습니다.',
-  [ErrorCode.A003]: '접근 권한이 없습니다.',
-
-  // 사용자 관련 에러
-  [ErrorCode.U000]: '사용자 관련 오류가 발생했습니다.',
-  [ErrorCode.U001]: '사용자를 찾을 수 없습니다.',
-  [ErrorCode.U002]: '이미 존재하는 사용자입니다.',
-
-  // 스케줄 관련 에러
-  [ErrorCode.S000]: '스케줄 관련 오류가 발생했습니다.',
-  [ErrorCode.S001]: '스케줄을 찾을 수 없습니다.',
-  [ErrorCode.S002]: '중복된 스케줄이 존재합니다.',
-
-  // 입력값 검증 관련 에러
-  [ErrorCode.V000]: '입력값 검증에 실패했습니다.',
-  [ErrorCode.V001]: '유효하지 않은 입력값입니다.',
-  [ErrorCode.V002]: '필수 필드가 누락되었습니다.',
+  /**
+   * Schedule Errors (S로 시작)
+   */
+  static readonly SCHEDULE_NOT_FOUND = new ErrorCode(
+    HttpStatus.NOT_FOUND,
+    'S001',
+    '일정을 찾을 수 없습니다.',
+  )
+  static readonly SCHEDULE_ALREADY_EXISTS = new ErrorCode(
+    HttpStatus.CONFLICT,
+    'S002',
+    '이미 존재하는 일정입니다.',
+  )
+  static readonly SCHEDULE_INVALID_DATE_RANGE = new ErrorCode(
+    HttpStatus.BAD_REQUEST,
+    'S003',
+    '유효하지 않은 일정 기간입니다.',
+  )
+  static readonly SCHEDULE_INVALID_RECURRING_CONFIG = new ErrorCode(
+    HttpStatus.BAD_REQUEST,
+    'S004',
+    '유효하지 않은 반복 일정 설정입니다.',
+  )
+  static readonly SCHEDULE_ACCESS_DENIED = new ErrorCode(
+    HttpStatus.FORBIDDEN,
+    'S005',
+    '해당 일정에 대한 접근 권한이 없습니다.',
+  )
 }

--- a/packages/server/src/common/exception/error-response.dto.ts
+++ b/packages/server/src/common/exception/error-response.dto.ts
@@ -1,0 +1,97 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { ErrorCode } from './error-codes.enum'
+
+// 필드 에러를 위한 인터페이스
+export interface FieldError {
+  field: string
+  message: string
+}
+
+// 유효성 검증 에러 상세 정보를 위한 인터페이스
+export interface ValidationErrorDetails {
+  fieldErrors: FieldError[]
+}
+
+// 에러 상세 정보의 타입 유니온
+export type ErrorDetails = ValidationErrorDetails | Record<string, unknown>
+
+export class ErrorResponseDto {
+  @ApiProperty({
+    description: 'HTTP 상태 코드',
+    example: 400,
+  })
+  statusCode: number
+
+  @ApiProperty({
+    description: '서비스 자체 에러 코드',
+    example: 'V001',
+    enum: ErrorCode,
+  })
+  errorCode: ErrorCode
+
+  @ApiProperty({
+    description: '에러 메시지',
+    example: '유효하지 않은 입력값입니다.',
+  })
+  message: string
+
+  @ApiProperty({
+    description: '에러 발생 시간',
+    example: '2023-10-31T12:34:56.789Z',
+  })
+  timestamp: string
+
+  @ApiProperty({
+    description: '상세 에러 내용 (선택적)',
+    required: false,
+    example: {
+      fieldErrors: [
+        {
+          field: 'email',
+          message: '유효한 이메일 형식이 아닙니다.',
+        },
+      ],
+    },
+  })
+  details?: ErrorDetails
+
+  constructor(
+    statusCode: number,
+    errorCode: ErrorCode,
+    message: string,
+    details?: ErrorDetails,
+  ) {
+    this.statusCode = statusCode
+    this.errorCode = errorCode
+    this.message = message
+    this.timestamp = new Date().toISOString()
+
+    if (details) {
+      this.details = details
+    }
+  }
+
+  /**
+   * 에러 응답 객체를 생성하는 정적 팩토리 메서드
+   */
+  static create(
+    statusCode: number,
+    errorCode: ErrorCode,
+    message: string,
+    details?: ErrorDetails,
+  ): ErrorResponseDto {
+    return new ErrorResponseDto(statusCode, errorCode, message, details)
+  }
+
+  /**
+   * 유효성 검증 에러에 대한 응답을 생성하는 팩토리 메서드
+   */
+  static createValidationError(
+    statusCode: number,
+    errorCode: ErrorCode,
+    message: string,
+    fieldErrors: FieldError[],
+  ): ErrorResponseDto {
+    return new ErrorResponseDto(statusCode, errorCode, message, { fieldErrors })
+  }
+}

--- a/packages/server/src/common/exception/error-response.dto.ts
+++ b/packages/server/src/common/exception/error-response.dto.ts
@@ -24,14 +24,13 @@ export class ErrorResponseDto {
 
   @ApiProperty({
     description: '서비스 자체 에러 코드',
-    example: 'V001',
-    enum: ErrorCode,
+    example: 'C001',
   })
-  errorCode: ErrorCode
+  errorCode: string
 
   @ApiProperty({
     description: '에러 메시지',
-    example: '유효하지 않은 입력값입니다.',
+    example: '잘못된 입력값입니다.',
   })
   message: string
 
@@ -57,7 +56,7 @@ export class ErrorResponseDto {
 
   constructor(
     statusCode: number,
-    errorCode: ErrorCode,
+    errorCode: string,
     message: string,
     details?: ErrorDetails,
   ) {
@@ -72,26 +71,42 @@ export class ErrorResponseDto {
   }
 
   /**
-   * 에러 응답 객체를 생성하는 정적 팩토리 메서드
+   * ErrorCode 객체로부터 에러 응답 객체를 생성하는 정적 팩토리 메서드
    */
-  static create(
-    statusCode: number,
+  static fromErrorCode(
+    errorCode: ErrorCode,
+    details?: ErrorDetails,
+  ): ErrorResponseDto {
+    return new ErrorResponseDto(
+      errorCode.status,
+      errorCode.code,
+      errorCode.message,
+      details,
+    )
+  }
+
+  /**
+   * 사용자 정의 메시지와 함께 에러 응답 객체를 생성하는 정적 팩토리 메서드
+   */
+  static fromErrorCodeWithMessage(
     errorCode: ErrorCode,
     message: string,
     details?: ErrorDetails,
   ): ErrorResponseDto {
-    return new ErrorResponseDto(statusCode, errorCode, message, details)
+    return new ErrorResponseDto(
+      errorCode.status,
+      errorCode.code,
+      message,
+      details,
+    )
   }
 
   /**
    * 유효성 검증 에러에 대한 응답을 생성하는 팩토리 메서드
    */
-  static createValidationError(
-    statusCode: number,
-    errorCode: ErrorCode,
-    message: string,
-    fieldErrors: FieldError[],
-  ): ErrorResponseDto {
-    return new ErrorResponseDto(statusCode, errorCode, message, { fieldErrors })
+  static createValidationError(fieldErrors: FieldError[]): ErrorResponseDto {
+    return ErrorResponseDto.fromErrorCode(ErrorCode.INVALID_INPUT_VALUE, {
+      fieldErrors,
+    })
   }
 }

--- a/packages/server/src/common/exception/global-exception.filter.ts
+++ b/packages/server/src/common/exception/global-exception.filter.ts
@@ -1,0 +1,207 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common'
+import { Request, Response } from 'express'
+import { BusinessException } from './business.exception'
+import { ErrorCode } from './error-codes.enum'
+import {
+  ErrorResponseDto,
+  ValidationErrorDetails,
+  FieldError,
+} from './error-response.dto'
+import { ValidationError } from 'class-validator'
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name)
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+    const request = ctx.getRequest<Request>()
+
+    // 요청 정보 로깅
+    const requestInfo = {
+      path: request.url,
+      method: request.method,
+      ip: request.ip,
+      userAgent: request.headers['user-agent'],
+    }
+
+    let errorResponse: ErrorResponseDto
+
+    // BusinessException 처리
+    if (exception instanceof BusinessException) {
+      const businessError = exception.getErrorResponse()
+
+      errorResponse = new ErrorResponseDto(
+        businessError.statusCode,
+        businessError.errorCode,
+        businessError.message,
+        businessError.details,
+      )
+
+      this.logger.warn(
+        `BusinessException: ${JSON.stringify({
+          ...requestInfo,
+          errorCode: businessError.errorCode,
+          statusCode: businessError.statusCode,
+          message: businessError.message,
+        })}`,
+      )
+    }
+    // NestJS HttpException 처리
+    else if (exception instanceof HttpException) {
+      const statusCode = exception.getStatus()
+      const exceptionResponse = exception.getResponse()
+
+      let message: string
+      let details: ValidationErrorDetails | undefined
+
+      // ValidationPipe에서 발생한 예외 처리
+      if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null &&
+        'message' in exceptionResponse
+      ) {
+        if (
+          Array.isArray(exceptionResponse['message']) &&
+          exceptionResponse['message'].length > 0 &&
+          typeof exceptionResponse['message'][0] === 'string'
+        ) {
+          // 단순 문자열 배열 메시지 처리
+          message = exceptionResponse['message'].join(', ')
+        } else if (
+          Array.isArray(exceptionResponse['message']) &&
+          exceptionResponse['message'].length > 0 &&
+          typeof exceptionResponse['message'][0] === 'object'
+        ) {
+          // class-validator ValidationError 객체 배열 처리
+          message = '입력값 검증에 실패했습니다.'
+          const validationErrors = exceptionResponse[
+            'message'
+          ] as ValidationError[]
+
+          // ValidationError 객체를 FieldError 형식으로 변환
+          const fieldErrors: FieldError[] =
+            this.flattenValidationErrors(validationErrors)
+
+          details = { fieldErrors }
+        } else {
+          // 다른 형태의 메시지 처리
+          message =
+            typeof exceptionResponse['message'] === 'string'
+              ? exceptionResponse['message']
+              : JSON.stringify(exceptionResponse['message'])
+        }
+      } else {
+        message =
+          typeof exceptionResponse === 'string'
+            ? exceptionResponse
+            : 'HTTP 에러가 발생했습니다.'
+      }
+
+      // 상태 코드에 따른 에러 코드 매핑
+      let errorCode: ErrorCode
+      switch (statusCode) {
+        case HttpStatus.BAD_REQUEST:
+          errorCode = ErrorCode.V000
+          break
+        case HttpStatus.UNAUTHORIZED:
+          errorCode = ErrorCode.A000
+          break
+        case HttpStatus.FORBIDDEN:
+          errorCode = ErrorCode.A003
+          break
+        case HttpStatus.NOT_FOUND:
+          errorCode = ErrorCode.G000
+          break
+        default:
+          errorCode = ErrorCode.G000
+      }
+
+      errorResponse = new ErrorResponseDto(
+        statusCode,
+        errorCode,
+        message,
+        details,
+      )
+
+      this.logger.warn(
+        `HttpException: ${JSON.stringify({
+          ...requestInfo,
+          statusCode,
+          errorCode,
+          message,
+        })}`,
+      )
+    }
+    // 그 외 모든 예외 처리 (500 Internal Server Error)
+    else {
+      const statusCode = HttpStatus.INTERNAL_SERVER_ERROR
+
+      // 예외 객체가 Error 인스턴스인 경우
+      let message: string
+      if (exception instanceof Error) {
+        message = exception.message || '서버 내부 오류가 발생했습니다.'
+
+        // 스택 트레이스 로깅
+        this.logger.error(
+          `Unhandled Error: ${exception.message}`,
+          exception.stack,
+        )
+      } else {
+        message = '알 수 없는 오류가 발생했습니다.'
+        this.logger.error(`Unknown Exception: ${JSON.stringify(exception)}`)
+      }
+
+      errorResponse = new ErrorResponseDto(statusCode, ErrorCode.G000, message)
+
+      this.logger.error(
+        `InternalServerError: ${JSON.stringify({
+          ...requestInfo,
+          message,
+        })}`,
+      )
+    }
+
+    // 응답 반환
+    response.status(errorResponse.statusCode).json(errorResponse)
+  }
+
+  /**
+   * class-validator의 ValidationError 객체를 평탄화하여 FieldError 배열로 변환
+   */
+  private flattenValidationErrors(
+    validationErrors: ValidationError[],
+  ): FieldError[] {
+    const fieldErrors: FieldError[] = []
+
+    const extractErrors = (error: ValidationError, parentPath = ''): void => {
+      const path = parentPath
+        ? `${parentPath}.${error.property}`
+        : error.property
+
+      // 제약 조건 오류 추출
+      if (error.constraints) {
+        const message =
+          Object.values(error.constraints)[0] || '유효하지 않은 값입니다.'
+        fieldErrors.push({ field: path, message })
+      }
+
+      // 하위 오류 재귀적 처리
+      if (error.children && error.children.length > 0) {
+        error.children.forEach((child) => extractErrors(child, path))
+      }
+    }
+
+    validationErrors.forEach((error) => extractErrors(error))
+
+    return fieldErrors
+  }
+}

--- a/packages/server/src/common/exception/global-exception.filter.ts
+++ b/packages/server/src/common/exception/global-exception.filter.ts
@@ -24,6 +24,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp()
     const response = ctx.getResponse<Response>()
     const request = ctx.getRequest<Request>()
+    const timestamp = new Date().toISOString()
 
     // 요청 정보 로깅
     const requestInfo = {
@@ -31,6 +32,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       method: request.method,
       ip: request.ip,
       userAgent: request.headers['user-agent'],
+      timestamp,
     }
 
     let errorResponse: ErrorResponseDto
@@ -177,8 +179,14 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       )
     }
 
-    // 응답 반환
-    response.status(errorResponse.statusCode).json(errorResponse)
+    // 응답 반환 - timestamp 필드가 ErrorResponseDto 생성자에서 자동으로 추가됨
+    response.status(errorResponse.statusCode).json({
+      statusCode: errorResponse.statusCode,
+      errorCode: errorResponse.errorCode,
+      message: errorResponse.message,
+      timestamp: errorResponse.timestamp,
+      ...(errorResponse.details && { details: errorResponse.details }),
+    })
   }
 
   /**

--- a/packages/server/src/modules/schedules/schedules.service.ts
+++ b/packages/server/src/modules/schedules/schedules.service.ts
@@ -19,6 +19,8 @@ import { Transactional } from 'typeorm-transactional'
 import { RecurringSchedulesService } from './recurring-schedules.service'
 import { ScheduleUtils } from './schedules.util'
 import { GroupScheduleService } from './group-schedules.service'
+import { BusinessException } from '@/common/exception/business.exception'
+import { ErrorCode } from '@/common/exception/error-codes.enum'
 
 @Injectable()
 export class SchedulesService {
@@ -191,7 +193,10 @@ export class SchedulesService {
       relations: ['category', 'recurring'],
     })
     if (!schedule) {
-      throw new NotFoundException(`Schedule with id: ${id} not found.`)
+      throw BusinessException.fromMessage(
+        ErrorCode.SCHEDULE_NOT_FOUND,
+        `ID가 ${id}인 일정을 찾을 수 없습니다.`,
+      )
     }
     return this.scheduleUtils.convertToResponseDto(schedule)
   }


### PR DESCRIPTION
## 🔗 이슈 번호
#75 
## ✅ 작업 내용
에러 처리와 에러 코드 관리를 하나의 파일에서 처리할 수 있도록 세팅함.
아래는 예시로서 에러메세지의 형태임.
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/9c14127d-cb99-4793-805b-99d4b7fd074f" />